### PR TITLE
Map flask container port to 5001 on host because 5000 is used by MacOS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - IMAGE_STORE_PATH=/mnt/images/
       - PUBLIC_IMAGE_FOLDER=http://localhost/images/
     ports:
-      - "5000:5000" # flask
+      - "5001:5000" # flask
       - "5678:5678" # debugpy
     depends_on:
       - mongo


### PR DESCRIPTION
Server-1 container won't start up on Mac if we use port 5000 because that port is in use by another MacOS service. I don't see any harm to using 5001 instead. This may address issue #42