### PR TITLE
Handle new `photos.fife.usercontent.google.com` url for user content

### DIFF
--- a/chrome_extension/src/scripts/google_photos_content.ts
+++ b/chrome_extension/src/scripts/google_photos_content.ts
@@ -28,7 +28,7 @@ function handleDeletePhoto(
     };
 
     try {
-      await waitForElement("img[aria-label][src*='googleusercontent.com']");
+      await waitForElement("img[aria-label][src*='usercontent']");
     } catch (error) {
       chrome.runtime.sendMessage({
         ...resultMessage,


### PR DESCRIPTION
It seems Google has changed their internal URLs hosting images from `lh3.googleusercontent.com` to `photos.fife.usercontent.google.com`. This broke the matcher within the Chrome extension that looks for the photo image on the page before it proceeds to delete. 

Update matcher to handle both the old domains (e.g. `lh3.googleusercontent.com`) as well as the new ones (`photos.fife.usercontent.google.com`).