### PR TITLE
Fix renamed install package to pip-install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ httplib2==0.22.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3
 idna==3.4; python_version >= '3.5'
 importlib-metadata==6.8.0; python_version < '3.10'
 importlib-resources==6.0.1; python_version < '3.10'
-install==1.3.5
+pip-install==1.3.5
 itsdangerous==2.1.2; python_version >= '3.7'
 jinja2==3.1.2; python_version >= '3.7'
 kiwisolver==1.4.4; python_version >= '3.7'


### PR DESCRIPTION
The `install` package has been renamed to `pip-install`, changing it so the image can be built again.