### PR TITLE
Update confirm button CSS classname

### DIFF
--- a/chrome_extension/src/scripts/google_photos_content.ts
+++ b/chrome_extension/src/scripts/google_photos_content.ts
@@ -51,7 +51,7 @@ function handleDeletePhoto(
     }
 
     try {
-      const confirmButton = await waitForElement("[jsshadow] [autofocus]");
+      const confirmButton = await waitForElement("[data-mdc-dialog-button-default]");
       confirmButton.click();
     } catch (error) {
       chrome.runtime.sendMessage({


### PR DESCRIPTION
Fixes https://github.com/mtalcott/google-photos-deduper/issues/71

CSS classname that was being observed on the confirmation button upon deleting a photo changed. One of the downsides of this approach.

Ideally I'd have [E2E tests running](https://github.com/mtalcott/google-photos-deduper/wiki#testing) to catch this sort of change and react more quickly rather than waiting for people to report it's broken, but alas, finite time!