### PR TITLE
Add GitHub release workflow and simplify README install instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Install Google-Photos-Toolkit dependencies
+        run: npm ci
+        working-directory: Google-Photos-Toolkit
+
+      - name: Build production package
+        run: npm run package
+
+      - name: Rename zip
+        run: mv build/chrome-mv3-prod.zip build/google-photos-deduper-${{ github.ref_name }}.zip
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: build/google-photos-deduper-*.zip

--- a/README.md
+++ b/README.md
@@ -19,46 +19,32 @@ No OAuth setup. No Google Cloud project. No data leaves your browser.
 
 [![Demo](https://google-photos-deduper-public.s3.amazonaws.com/demo-l.gif)](https://youtu.be/QDUGKgQOa7o)
 
-## Setup
+## Install
 
-### Prerequisites
+1. Go to [Releases](../../releases/latest) and download the latest `google-photos-deduper-vX.X.X.zip`
+2. Unzip the file to a permanent folder (don't delete it — Chrome needs it to stay there)
+3. Open Chrome → Extensions (`chrome://extensions`)
+4. Enable **Developer mode** (toggle, top-right)
+5. Click **Load unpacked** → select the unzipped folder
+6. The extension icon appears in your toolbar — pin it for easy access
 
-- Google Chrome
-- Node.js 20+
+## Development
 
-### Install
+### Setup
+
+**Prerequisites:** Google Chrome, Node.js 20+
 
 ```bash
 git clone https://github.com/mtalcott/google-photos-deduper.git
 cd google-photos-deduper
 git submodule update --init --recursive
 npm install
+npm run build  # builds into build/chrome-mv3-dev/
 ```
 
-### Build
+Load in Chrome: `chrome://extensions` → enable **Developer mode** → **Load unpacked** → select `build/chrome-mv3-dev/`.
 
-```bash
-npm run build
-```
-
-This builds GPTK (the Google Photos API wrapper) and then the extension into `build/chrome-mv3-dev/`.
-
-### Load in Chrome
-
-1. Open `chrome://extensions`
-2. Enable **Developer mode** (top right)
-3. Click **Load unpacked**
-4. Select the `build/chrome-mv3-dev/` folder
-
-### Use
-
-1. Open [Google Photos](https://photos.google.com) in Chrome and make sure you're logged in
-2. Click the **Google Photos Deduper** extension icon
-3. Click **Open Deduper**
-4. Click **Scan Library** and wait for the scan to complete (time varies by library size)
-5. Review duplicate groups, then click **Move to Trash** to remove the duplicates
-
-## Development
+### Commands
 
 ```bash
 # Start the Plasmo dev server (rebuilds on file changes)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml`: triggers on `v*.*.*` tags, builds a production zip, and publishes it as a GitHub release with auto-generated release notes via `softprops/action-gh-release@v2`
- Rewrites README for the standalone Chrome extension (replaces old Python web app docs), with How It Works + Demo at the top, a flat **Install** section (zip download, no build required), and build-from-source moved into **Development**

## Test plan

- [x] Push a test tag: `git tag v2.0.1-test && git push origin v2.0.1-test`
- [ ] Confirm the `release` workflow runs in GitHub Actions
- [ ] Confirm a GitHub release is created with `google-photos-deduper-v2.0.1-test.zip` attached
- [ ] Download zip, unzip, load as unpacked extension in Chrome — verify it works
- [ ] Clean up: `git tag -d v2.0.1-test && git push origin --delete v2.0.1-test`