### PR TITLE
Fix release build: plasmo build step, upgrade actions to v5/Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
   test:
     name: Unit & integration tests
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,14 @@ jobs:
   test:
     name: Unit & integration tests
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,17 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install root dependencies

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "sync:scripts": "cp scripts/google-photos-commands.js build/chrome-mv3-dev/scripts/ 2>/dev/null || true",
     "dev": "npm run build:gptk && npm run copy:wasm && plasmo dev",
     "build": "npm run build:gptk && npm run copy:wasm && plasmo build && cp -r build/chrome-mv3-prod/. build/chrome-mv3-dev/",
-    "package": "npm run build:gptk && npm run copy:wasm && plasmo package"
+    "package": "npm run build:gptk && npm run copy:wasm && plasmo build && plasmo package"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",


### PR DESCRIPTION
## Summary

- `package` script: add `plasmo build` before `plasmo package` — `plasmo package` only zips, it doesn't build, so the `build/` directory must exist first
- `ci.yml` + `release.yml`: upgrade `actions/checkout` and `actions/setup-node` to v5 (Node 24), dropping the now-deprecated v4 versions

## Test plan

- [x] Confirm CI passes on this PR
- [x] Push a test tag: `git tag v2.0.1-test && git push origin v2.0.1-test`
- [x] Confirm release workflow completes and attaches `google-photos-deduper-v2.0.1-test.zip`
- [x] Clean up: `git tag -d v2.0.1-test && git push origin --delete v2.0.1-test`