### PR TITLE
Add direct download link for latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,14 @@ jobs:
         run: npm run package
 
       - name: Rename zip
-        run: mv build/chrome-mv3-prod.zip build/google-photos-deduper-${{ github.ref_name }}.zip
+        run: |
+          cp build/chrome-mv3-prod.zip build/google-photos-deduper-${{ github.ref_name }}.zip
+          cp build/chrome-mv3-prod.zip build/google-photos-deduper.zip
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: build/google-photos-deduper-*.zip
+          files: |
+            build/google-photos-deduper-${{ github.ref_name }}.zip
+            build/google-photos-deduper.zip

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Chrome extension that finds and removes duplicate photos from your Google Phot
 
 Built with [Plasmo](https://plasmo.com/), [MediaPipe](https://developers.google.com/mediapipe), [React](https://react.dev/), and [MUI](https://mui.com/). Uses [Google Photos Toolkit (GPTK)](https://github.com/xob0t/Google-Photos-Toolkit) to access your library via Google Photos' web interface.
 
-## How It Works
+## Usage
 
 1. Open Google Photos in Chrome with the extension installed
 2. Click the extension icon → **Open Deduper**
@@ -15,9 +15,11 @@ Built with [Plasmo](https://plasmo.com/), [MediaPipe](https://developers.google.
 
 No OAuth setup. No Google Cloud project. No data leaves your browser.
 
+<!--
 ## Demo
 
 [![Demo](https://google-photos-deduper-public.s3.amazonaws.com/demo-l.gif)](https://youtu.be/QDUGKgQOa7o)
+-->
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,6 @@ A Chrome extension that finds and removes duplicate photos from your Google Phot
 
 Built with [Plasmo](https://plasmo.com/), [MediaPipe](https://developers.google.com/mediapipe), [React](https://react.dev/), and [MUI](https://mui.com/). Uses [Google Photos Toolkit (GPTK)](https://github.com/xob0t/Google-Photos-Toolkit) to access your library via Google Photos' web interface.
 
-## Usage
-
-1. Open Google Photos in Chrome with the extension installed
-2. Click the extension icon → **Open Deduper**
-3. Click **Scan Library** - the extension fetches your media items and uses MediaPipe image embeddings locally to find visually identical photos
-4. Review the duplicate groups, select which to keep, and click **Move to Trash**
-
-No OAuth setup. No Google Cloud project. No data leaves your browser.
-
 <!--
 ## Demo
 
@@ -29,6 +20,15 @@ No OAuth setup. No Google Cloud project. No data leaves your browser.
 2. Open `chrome://extensions` → enable **Developer mode** (toggle, top-right)
 3. Click **Load unpacked** → select the unzipped folder
 4. Pin the extension icon in your toolbar for easy access
+
+## Usage
+
+1. Open Google Photos in Chrome with the extension installed
+2. Click the extension icon → **Open Deduper**
+3. Click **Scan Library** - the extension fetches your media items and uses MediaPipe image embeddings locally to find visually identical photos
+4. Review the duplicate groups, select which to keep, and click **Move to Trash**
+
+No OAuth setup. No Google Cloud project. No data leaves your browser.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ No OAuth setup. No Google Cloud project. No data leaves your browser.
 
 ## Install
 
-1. Go to [Releases](../../releases/latest) and download the latest `google-photos-deduper-vX.X.X.zip`
-2. Unzip the file to a permanent folder (don't delete it — Chrome needs it to stay there)
-3. Open Chrome → Extensions (`chrome://extensions`)
-4. Enable **Developer mode** (toggle, top-right)
-5. Click **Load unpacked** → select the unzipped folder
-6. The extension icon appears in your toolbar — pin it for easy access
+**[⬇ Download latest release](https://github.com/mtalcott/google-photos-deduper/releases/latest/download/google-photos-deduper.zip)**
+
+1. Unzip to a permanent folder (don't delete it — Chrome needs it to stay there)
+2. Open `chrome://extensions` → enable **Developer mode** (toggle, top-right)
+3. Click **Load unpacked** → select the unzipped folder
+4. Pin the extension icon in your toolbar for easy access
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Upload a static-named `google-photos-deduper.zip` alongside the versioned zip in the release workflow, enabling the `/releases/latest/download/` permanent URL pattern
- Replace the 6-step install section in the README with a prominent direct download link + 4 streamlined steps

## Test plan

- [ ] Trigger a release and verify both `google-photos-deduper-vX.X.X.zip` and `google-photos-deduper.zip` appear as assets
- [ ] Confirm `https://github.com/mtalcott/google-photos-deduper/releases/latest/download/google-photos-deduper.zip` redirects to the latest zip