### PR TITLE
Add photo viewer modal and multi-keep support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ venv/
 # Build output
 build/
 .plasmo
+tsconfig.tsbuildinfo
 
 # Scripts generated at build time
 scripts/google-photos-toolkit.user.js

--- a/components/DuplicateGroups.tsx
+++ b/components/DuplicateGroups.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import Box from "@mui/material/Box"
 import Card from "@mui/material/Card"
 import CardActionArea from "@mui/material/CardActionArea"
@@ -6,32 +6,13 @@ import CardContent from "@mui/material/CardContent"
 import CardMedia from "@mui/material/CardMedia"
 import Checkbox from "@mui/material/Checkbox"
 import Chip from "@mui/material/Chip"
+import IconButton from "@mui/material/IconButton"
 import Paper from "@mui/material/Paper"
 import Typography from "@mui/material/Typography"
+import OpenInFullIcon from "@mui/icons-material/OpenInFull"
+import { useBlobUrl } from "./useBlobUrl"
+import { PhotoViewerModal } from "./PhotoViewerModal"
 import type { GpdMediaItem, DuplicateGroup } from "../lib/types"
-
-/**
- * Fetch a thumbnail via fetch() (which uses extension host_permissions + cookies)
- * and return a blob URL that <img> can display.
- */
-function useBlobUrl(url: string | undefined): string | undefined {
-  const [blobUrl, setBlobUrl] = useState<string>()
-  useEffect(() => {
-    if (!url) return
-    let revoked = false
-    fetch(url, { credentials: "include" })
-      .then((r) => (r.ok ? r.blob() : null))
-      .then((blob) => {
-        if (blob && !revoked) setBlobUrl(URL.createObjectURL(blob))
-      })
-      .catch(() => {})
-    return () => {
-      revoked = true
-      if (blobUrl) URL.revokeObjectURL(blobUrl)
-    }
-  }, [url])
-  return blobUrl
-}
 
 function ThumbnailImage({ src, alt }: { src: string; alt: string }) {
   const blobUrl = useBlobUrl(src)
@@ -50,8 +31,8 @@ interface DuplicateGroupsProps {
   mediaItems: Record<string, GpdMediaItem>
   selectedGroupIds: Set<string>
   onToggleGroup: (groupId: string) => void
-  getOriginal: (group: DuplicateGroup) => string
-  onSetOriginal: (groupId: string, mediaKey: string) => void
+  getKept: (group: DuplicateGroup) => Set<string>
+  onToggleKept: (group: DuplicateGroup, mediaKey: string) => void
 }
 
 export function DuplicateGroups({
@@ -59,9 +40,14 @@ export function DuplicateGroups({
   mediaItems,
   selectedGroupIds,
   onToggleGroup,
-  getOriginal,
-  onSetOriginal,
+  getKept,
+  onToggleKept,
 }: DuplicateGroupsProps) {
+  const [viewerState, setViewerState] = useState<{
+    group: DuplicateGroup
+    index: number
+  } | null>(null)
+
   if (groups.length === 0) {
     const totalItems = Object.keys(mediaItems).length
     return (
@@ -77,6 +63,13 @@ export function DuplicateGroups({
     )
   }
 
+  const viewerGroup = viewerState?.group ?? null
+  const viewerItems = viewerGroup
+    ? viewerGroup.mediaKeys
+        .map((k) => mediaItems[k])
+        .filter((item): item is GpdMediaItem => !!item)
+    : []
+
   return (
     <Box sx={{ pb: 6 }}>
       <Typography variant="h6" fontWeight={600} sx={{ px: 0, py: 2 }}>
@@ -85,7 +78,7 @@ export function DuplicateGroups({
 
       {groups.map((group) => {
         const isSelected = selectedGroupIds.has(group.id)
-        const original = getOriginal(group)
+        const keptSet = getKept(group)
 
         return (
           <Paper
@@ -138,98 +131,141 @@ export function DuplicateGroups({
                 gap: 1.5,
                 p: 1.5,
               }}>
-              {group.mediaKeys.map((key) => {
+              {group.mediaKeys.map((key, itemIndex) => {
                 const item = mediaItems[key]
                 if (!item) return null
-                const isOriginal = key === original
+                const isKept = keptSet.has(key)
 
                 return (
-                  <Card
+                  <Box
                     key={key}
-                    variant="outlined"
                     sx={{
+                      position: "relative",
                       width: 160,
                       flexShrink: 0,
-                      borderColor: isOriginal ? "primary.main" : "divider",
-                      borderWidth: isOriginal ? 2 : 1,
-                      transition: "border-color 0.15s",
+                      "& .viewer-btn": { opacity: 0 },
+                      "&:hover .viewer-btn": { opacity: 1 },
                     }}>
-                    <CardActionArea onClick={() => onSetOriginal(group.id, key)}>
-                      <ThumbnailImage
-                        src={item.thumb + "=w200-h200"}
-                        alt={item.fileName || item.mediaKey}
-                      />
-                      <CardContent
-                        sx={{
-                          p: 1,
-                          "&:last-child": { pb: 1 },
-                          display: "flex",
-                          flexDirection: "column",
-                          gap: 0.5,
-                        }}>
-                        {item.fileName && (
-                          <Typography
-                            variant="caption"
-                            display="block"
-                            noWrap
-                            title={item.fileName}>
-                            {item.fileName}
-                          </Typography>
-                        )}
-                        {item.resWidth && item.resHeight && (
-                          <Typography
-                            variant="caption"
-                            color="text.secondary"
-                            sx={{ fontFamily: "monospace" }}>
-                            {item.resWidth}×{item.resHeight}
-                          </Typography>
-                        )}
-                        {item.timestamp ? (
-                          <Typography variant="caption" color="text.secondary" display="block">
-                            <span style={{ opacity: 0.6 }}>Taken </span>
-                            {new Date(item.timestamp).toLocaleDateString(undefined, {
-                              year: "numeric",
-                              month: "short",
-                              day: "numeric",
-                            })}
-                          </Typography>
-                        ) : null}
-                        {item.creationTimestamp ? (
-                          <Typography variant="caption" color="text.secondary" display="block">
-                            <span style={{ opacity: 0.6 }}>Uploaded </span>
-                            {new Date(item.creationTimestamp).toLocaleDateString(undefined, {
-                              year: "numeric",
-                              month: "short",
-                              day: "numeric",
-                            })}
-                          </Typography>
-                        ) : null}
-                        {isOriginal ? (
-                          <Chip
-                            label="Keep"
-                            size="small"
-                            color="primary"
-                            variant="outlined"
-                            sx={{ width: "fit-content", height: 20, fontSize: 11 }}
-                          />
-                        ) : isSelected ? (
-                          <Chip
-                            label="Trash"
-                            size="small"
-                            color="error"
-                            variant="outlined"
-                            sx={{ width: "fit-content", height: 20, fontSize: 11 }}
-                          />
-                        ) : null}
-                      </CardContent>
-                    </CardActionArea>
-                  </Card>
+                    <Card
+                      variant="outlined"
+                      sx={{
+                        width: "100%",
+                        borderColor: isKept ? "primary.main" : "divider",
+                        borderWidth: isKept ? 2 : 1,
+                        transition: "border-color 0.15s",
+                      }}>
+                      <CardActionArea onClick={() => onToggleKept(group, key)}>
+                        <ThumbnailImage
+                          src={item.thumb + "=w200-h200"}
+                          alt={item.fileName || item.mediaKey}
+                        />
+                        <CardContent
+                          sx={{
+                            p: 1,
+                            "&:last-child": { pb: 1 },
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 0.5,
+                          }}>
+                          {item.fileName && (
+                            <Typography
+                              variant="caption"
+                              display="block"
+                              noWrap
+                              title={item.fileName}>
+                              {item.fileName}
+                            </Typography>
+                          )}
+                          {item.resWidth && item.resHeight && (
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                              sx={{ fontFamily: "monospace" }}>
+                              {item.resWidth}×{item.resHeight}
+                            </Typography>
+                          )}
+                          {item.timestamp ? (
+                            <Typography variant="caption" color="text.secondary" display="block">
+                              <span style={{ opacity: 0.6 }}>Taken </span>
+                              {new Date(item.timestamp).toLocaleDateString(undefined, {
+                                year: "numeric",
+                                month: "short",
+                                day: "numeric",
+                              })}
+                            </Typography>
+                          ) : null}
+                          {item.creationTimestamp ? (
+                            <Typography variant="caption" color="text.secondary" display="block">
+                              <span style={{ opacity: 0.6 }}>Uploaded </span>
+                              {new Date(item.creationTimestamp).toLocaleDateString(undefined, {
+                                year: "numeric",
+                                month: "short",
+                                day: "numeric",
+                              })}
+                            </Typography>
+                          ) : null}
+                          {isKept ? (
+                            <Chip
+                              label="Keep"
+                              size="small"
+                              color="primary"
+                              variant="outlined"
+                              sx={{ width: "fit-content", height: 20, fontSize: 11 }}
+                            />
+                          ) : isSelected ? (
+                            <Chip
+                              label="Trash"
+                              size="small"
+                              color="error"
+                              variant="outlined"
+                              sx={{ width: "fit-content", height: 20, fontSize: 11 }}
+                            />
+                          ) : null}
+                        </CardContent>
+                      </CardActionArea>
+                    </Card>
+
+                    {/* Zoom overlay — secondary action, does not trigger Keep toggle */}
+                    <IconButton
+                      className="viewer-btn"
+                      size="small"
+                      aria-label="View full size"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setViewerState({ group, index: itemIndex })
+                      }}
+                      sx={{
+                        position: "absolute",
+                        top: 4,
+                        right: 4,
+                        bgcolor: "rgba(0,0,0,0.45)",
+                        color: "white",
+                        transition: "opacity 0.15s",
+                        minWidth: 32,
+                        minHeight: 32,
+                        "&:hover": { bgcolor: "rgba(0,0,0,0.65)" },
+                      }}>
+                      <OpenInFullIcon sx={{ fontSize: 14 }} />
+                    </IconButton>
+                  </Box>
                 )
               })}
             </Box>
           </Paper>
         )
       })}
+
+      {/* Photo viewer modal — rendered once outside the map, state drives which photo */}
+      {viewerGroup && (
+        <PhotoViewerModal
+          open={true}
+          items={viewerItems}
+          initialIndex={viewerState!.index}
+          keptSet={getKept(viewerGroup)}
+          isGroupSelected={selectedGroupIds.has(viewerGroup.id)}
+          onClose={() => setViewerState(null)}
+        />
+      )}
     </Box>
   )
 }

--- a/components/PhotoViewerModal.tsx
+++ b/components/PhotoViewerModal.tsx
@@ -1,0 +1,371 @@
+import { useState, useEffect } from "react"
+import { keyframes } from "@emotion/react"
+import Box from "@mui/material/Box"
+import CardMedia from "@mui/material/CardMedia"
+import Chip from "@mui/material/Chip"
+import CircularProgress from "@mui/material/CircularProgress"
+import Dialog from "@mui/material/Dialog"
+import DialogContent from "@mui/material/DialogContent"
+import IconButton from "@mui/material/IconButton"
+import Link from "@mui/material/Link"
+import Typography from "@mui/material/Typography"
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft"
+import ChevronRightIcon from "@mui/icons-material/ChevronRight"
+import CloseIcon from "@mui/icons-material/Close"
+import OpenInNewIcon from "@mui/icons-material/OpenInNew"
+import type { GpdMediaItem } from "../lib/types"
+
+/**
+ * Preloads full-res blob URLs for all items in the group as soon as the modal
+ * opens. Returns a stable map of mediaKey → blobUrl so navigating between
+ * images is instant (no per-image fetch on demand).
+ *
+ * Deps are the joined thumb URLs so the effect only re-runs when the group
+ * actually changes, not on every render.
+ */
+function useGroupBlobUrls(items: GpdMediaItem[]): Record<string, string | undefined> {
+  const [blobUrls, setBlobUrls] = useState<Record<string, string>>({})
+
+  const thumbKey = items.map((i) => i.thumb).join("|")
+
+  useEffect(() => {
+    const controllers: AbortController[] = []
+    const createdUrls: string[] = []
+    let cancelled = false
+
+    setBlobUrls({})
+
+    items.forEach((item) => {
+      const controller = new AbortController()
+      controllers.push(controller)
+
+      fetch(item.thumb, { credentials: "include", signal: controller.signal })
+        .then((r) => (r.ok ? r.blob() : null))
+        .then((blob) => {
+          if (blob && !cancelled) {
+            const url = URL.createObjectURL(blob)
+            createdUrls.push(url)
+            setBlobUrls((prev) => ({ ...prev, [item.mediaKey]: url }))
+          }
+        })
+        .catch(() => {})
+    })
+
+    return () => {
+      cancelled = true
+      controllers.forEach((c) => c.abort())
+      createdUrls.forEach((url) => URL.revokeObjectURL(url))
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [thumbKey])
+
+  return blobUrls
+}
+
+interface FullResImageProps {
+  item: GpdMediaItem
+  blobUrl: string | undefined
+}
+
+function FullResImage({ item, blobUrl }: FullResImageProps) {
+  if (!blobUrl) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: "100%",
+          height: "100%",
+        }}>
+        <CircularProgress sx={{ color: "white" }} />
+      </Box>
+    )
+  }
+  return (
+    <CardMedia
+      component="img"
+      image={blobUrl}
+      alt={item.fileName || item.mediaKey}
+      sx={{
+        maxWidth: "100%",
+        maxHeight: "100%",
+        objectFit: "contain",
+        display: "block",
+        mx: "auto",
+      }}
+    />
+  )
+}
+
+export interface PhotoViewerModalProps {
+  open: boolean
+  items: GpdMediaItem[]
+  initialIndex: number
+  keptSet: Set<string>
+  isGroupSelected: boolean
+  onClose: () => void
+}
+
+const slideInFromRight = keyframes`
+  from { transform: translateX(10px); opacity: 0; }
+  to   { transform: translateX(0);    opacity: 1; }
+`
+const slideInFromLeft = keyframes`
+  from { transform: translateX(-10px); opacity: 0; }
+  to   { transform: translateX(0);     opacity: 1; }
+`
+
+export function PhotoViewerModal({
+  open,
+  items,
+  initialIndex,
+  keptSet,
+  isGroupSelected,
+  onClose,
+}: PhotoViewerModalProps) {
+  const [index, setIndex] = useState(initialIndex)
+  const [slideDir, setSlideDir] = useState<"forward" | "backward">("forward")
+
+  // Preload all images in the group up front
+  const blobUrls = useGroupBlobUrls(items)
+
+  // Reset index when the modal opens or the initial photo changes
+  useEffect(() => {
+    setIndex(initialIndex)
+  }, [open, initialIndex])
+
+  const navigate = (newIndex: number) => {
+    if (newIndex === index) return
+    setSlideDir(newIndex > index ? "forward" : "backward")
+    setIndex(newIndex)
+  }
+
+  // Keyboard navigation (arrow keys only; MUI Dialog handles Escape → onClose)
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "ArrowLeft") navigate(Math.max(0, index - 1))
+      if (e.key === "ArrowRight") navigate(Math.min(items.length - 1, index + 1))
+    }
+    window.addEventListener("keydown", handler)
+    return () => window.removeEventListener("keydown", handler)
+  }, [open, index, items.length])
+
+  if (items.length === 0) return null
+
+  const safeIndex = Math.min(index, items.length - 1)
+  const item = items[safeIndex]
+  const isKept = keptSet.has(item.mediaKey)
+  const isFirst = safeIndex === 0
+  const isLast = safeIndex === items.length - 1
+
+  const takenDate = item.timestamp
+    ? new Date(item.timestamp).toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      })
+    : null
+
+  const uploadedDate = item.creationTimestamp
+    ? new Date(item.creationTimestamp).toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      })
+    : null
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="lg"
+      aria-label="Photo viewer"
+      PaperProps={{
+        sx: {
+          bgcolor: "#111",
+          color: "white",
+          position: "relative",
+          overflow: "hidden",
+        },
+      }}>
+      {/* Header bar: filename left, counter center, close right */}
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: "1fr auto 1fr",
+          alignItems: "center",
+          px: 1,
+          py: 0.5,
+          borderBottom: "1px solid rgba(255,255,255,0.1)",
+        }}>
+        <Typography
+          variant="caption"
+          noWrap
+          sx={{ color: "rgba(255,255,255,0.45)", pl: 1 }}>
+          {item.fileName || ""}
+        </Typography>
+
+        {/* Counter — centered, prominent, slides on navigation */}
+        {items.length > 1 && (
+          <Typography
+            key={safeIndex}
+            variant="body2"
+            fontWeight={600}
+            sx={{
+              color: "white",
+              textAlign: "center",
+              letterSpacing: "0.05em",
+              animation: `${slideDir === "forward" ? slideInFromRight : slideInFromLeft} 150ms ease-out`,
+            }}>
+            {safeIndex + 1} / {items.length}
+          </Typography>
+        )}
+
+        <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+          <IconButton
+            onClick={onClose}
+            aria-label="Close photo viewer"
+            size="small"
+            sx={{ color: "white", minWidth: 44, minHeight: 44 }}>
+            <CloseIcon />
+          </IconButton>
+        </Box>
+      </Box>
+
+      {/* Image area with prev/next buttons */}
+      <DialogContent
+        sx={{
+          p: 0,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          position: "relative",
+          bgcolor: "#111",
+          height: "70vh",
+          overflow: "hidden",
+        }}>
+        {/* Previous */}
+        <IconButton
+          onClick={() => navigate(Math.max(0, safeIndex - 1))}
+          disabled={isFirst}
+          aria-label="Previous photo"
+          sx={{
+            position: "absolute",
+            left: 8,
+            color: "white",
+            bgcolor: "rgba(0,0,0,0.4)",
+            minWidth: 44,
+            minHeight: 44,
+            zIndex: 1,
+            "&:hover": { bgcolor: "rgba(0,0,0,0.65)" },
+            "&.Mui-disabled": { color: "rgba(255,255,255,0.2)" },
+          }}>
+          <ChevronLeftIcon />
+        </IconButton>
+
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: "100%",
+            height: "100%",
+          }}>
+          <FullResImage item={item} blobUrl={blobUrls[item.mediaKey]} />
+        </Box>
+
+        {/* Next */}
+        <IconButton
+          onClick={() => navigate(Math.min(items.length - 1, safeIndex + 1))}
+          disabled={isLast}
+          aria-label="Next photo"
+          sx={{
+            position: "absolute",
+            right: 8,
+            color: "white",
+            bgcolor: "rgba(0,0,0,0.4)",
+            minWidth: 44,
+            minHeight: 44,
+            zIndex: 1,
+            "&:hover": { bgcolor: "rgba(0,0,0,0.65)" },
+            "&.Mui-disabled": { color: "rgba(255,255,255,0.2)" },
+          }}>
+          <ChevronRightIcon />
+        </IconButton>
+      </DialogContent>
+
+      {/* Footer bar */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          flexWrap: "wrap",
+          gap: 1.5,
+          px: 2,
+          py: 1.5,
+          borderTop: "1px solid rgba(255,255,255,0.1)",
+        }}>
+        {/* Metadata */}
+        <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", flex: 1 }}>
+          {item.resWidth && item.resHeight && (
+            <Typography variant="caption" sx={{ color: "rgba(255,255,255,0.6)", fontFamily: "monospace" }}>
+              {item.resWidth}×{item.resHeight}
+            </Typography>
+          )}
+          {takenDate && (
+            <Typography variant="caption" sx={{ color: "rgba(255,255,255,0.6)" }}>
+              <span style={{ opacity: 0.6 }}>Taken </span>{takenDate}
+            </Typography>
+          )}
+          {uploadedDate && (
+            <Typography variant="caption" sx={{ color: "rgba(255,255,255,0.6)" }}>
+              <span style={{ opacity: 0.6 }}>Uploaded </span>{uploadedDate}
+            </Typography>
+          )}
+        </Box>
+
+        {/* Keep/Trash chip */}
+        {isKept ? (
+          <Chip
+            label="Keep"
+            size="small"
+            color="primary"
+            variant="outlined"
+            sx={{ height: 20, fontSize: 11, borderColor: "rgba(99,179,237,0.8)", color: "rgba(99,179,237,1)" }}
+          />
+        ) : isGroupSelected ? (
+          <Chip
+            label="Trash"
+            size="small"
+            color="error"
+            variant="outlined"
+            sx={{ height: 20, fontSize: 11, borderColor: "rgba(252,129,129,0.8)", color: "rgba(252,129,129,1)" }}
+          />
+        ) : null}
+
+        {/* View in Google Photos link */}
+        {item.productUrl && (
+          <Link
+            href={item.productUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="caption"
+            sx={{
+              color: "rgba(255,255,255,0.7)",
+              display: "flex",
+              alignItems: "center",
+              gap: 0.5,
+              textDecoration: "none",
+              "&:hover": { color: "white" },
+            }}>
+            View in Google Photos
+            <OpenInNewIcon sx={{ fontSize: 12 }} />
+          </Link>
+        )}
+      </Box>
+    </Dialog>
+  )
+}

--- a/components/useBlobUrl.ts
+++ b/components/useBlobUrl.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from "react"
+
+/**
+ * Fetch a URL via fetch() (which uses extension host_permissions + cookies)
+ * and return a blob URL that <img> can display. Revokes the blob URL on cleanup.
+ */
+export function useBlobUrl(url: string | undefined): string | undefined {
+  const [blobUrl, setBlobUrl] = useState<string>()
+
+  useEffect(() => {
+    if (!url) return
+    let revoked = false
+    let objectUrl: string | undefined
+
+    fetch(url, { credentials: "include" })
+      .then((r) => (r.ok ? r.blob() : null))
+      .then((blob) => {
+        if (blob && !revoked) {
+          objectUrl = URL.createObjectURL(blob)
+          setBlobUrl(objectUrl)
+        }
+      })
+      .catch(() => {})
+
+    return () => {
+      revoked = true
+      if (objectUrl) URL.revokeObjectURL(objectUrl)
+    }
+  }, [url])
+
+  return blobUrl
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -149,7 +149,8 @@ export type AppMessage =
 export interface GpdMediaItem {
   mediaKey: string;
   dedupKey: string;
-  thumb: string; // thumbnail URL
+  thumb: string; // thumbnail URL (append =w200-h200 for thumbnails; use bare for full-res)
+  productUrl?: string; // link to item in Google Photos web app
   timestamp: number; // taken date
   creationTimestamp: number; // upload date
   resWidth?: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,11 +32,13 @@
         "@types/react": "18.2.48",
         "@types/react-dom": "18.2.18",
         "@types/react-window": "^1.8.8",
+        "@vitejs/plugin-react": "^6.0.1",
         "@vitest/ui": "^4.1.2",
         "happy-dom": "^20.8.9",
         "jsdom": "^29.0.1",
         "prettier": "3.2.4",
         "typescript": "5.3.3",
+        "vite": "^8.0.7",
         "vitest": "^4.1.2"
       }
     },
@@ -543,38 +545,35 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -751,24 +750,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.20",
@@ -1026,24 +1007,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
@@ -1060,24 +1023,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
@@ -1092,24 +1037,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1721,9 +1648,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1775,9 +1702,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.123.0.tgz",
+      "integrity": "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5022,9 +4949,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==",
       "cpu": [
         "arm64"
       ],
@@ -5039,9 +4966,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==",
       "cpu": [
         "arm64"
       ],
@@ -5056,9 +4983,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==",
       "cpu": [
         "x64"
       ],
@@ -5073,9 +5000,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==",
       "cpu": [
         "x64"
       ],
@@ -5090,9 +5017,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.13.tgz",
+      "integrity": "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==",
       "cpu": [
         "arm"
       ],
@@ -5107,9 +5034,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==",
       "cpu": [
         "arm64"
       ],
@@ -5124,9 +5051,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==",
       "cpu": [
         "arm64"
       ],
@@ -5141,9 +5068,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==",
       "cpu": [
         "ppc64"
       ],
@@ -5158,9 +5085,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==",
       "cpu": [
         "s390x"
       ],
@@ -5175,9 +5102,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==",
       "cpu": [
         "x64"
       ],
@@ -5192,9 +5119,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==",
       "cpu": [
         "x64"
       ],
@@ -5209,9 +5136,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==",
       "cpu": [
         "arm64"
       ],
@@ -5226,9 +5153,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.13.tgz",
+      "integrity": "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==",
       "cpu": [
         "wasm32"
       ],
@@ -5236,16 +5163,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.9.1",
+        "@emnapi/runtime": "1.9.1",
+        "@napi-rs/wasm-runtime": "^1.1.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==",
       "cpu": [
         "arm64"
       ],
@@ -5260,9 +5189,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==",
       "cpu": [
         "x64"
       ],
@@ -5277,9 +5206,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+      "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5872,38 +5801,6 @@
         "node": ">=14.16"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -5969,14 +5866,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/canvas-confetti": {
       "version": "1.9.0",
@@ -6081,6 +5970,7 @@
       "version": "18.2.48",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.48.tgz",
       "integrity": "sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -6127,6 +6017,7 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
@@ -6151,6 +6042,39 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitejs/plugin-react/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
@@ -7428,17 +7352,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
@@ -7462,14 +7375,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -9375,17 +9280,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -10492,44 +10386,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -10872,14 +10728,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.123.0",
+        "@rolldown/pluginutils": "1.0.0-rc.13"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -10888,21 +10744,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.13",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13"
       }
     },
     "node_modules/rollup": {
@@ -12106,7 +11962,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12202,6 +12058,97 @@
         "node": ">= 4"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.7.tgz",
+      "integrity": "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.13",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vitest": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
@@ -12284,402 +12231,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
@@ -12707,50 +12258,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
     "node_modules/vitest/node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -12772,102 +12279,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/vitest/node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/vue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/chrome": "0.0.258",
-        "@types/node": "20.11.5",
+        "@types/node": "^20.19.39",
         "@types/react": "18.2.48",
         "@types/react-dom": "18.2.18",
         "@types/react-window": "^1.8.8",
@@ -751,10 +751,27 @@
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
       ],
@@ -763,14 +780,15 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
       ],
@@ -779,14 +797,15 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
       ],
@@ -795,14 +814,15 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
       ],
@@ -811,14 +831,15 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
-      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
       ],
@@ -827,14 +848,15 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
       ],
@@ -843,14 +865,15 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
       ],
@@ -859,14 +882,15 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
       ],
@@ -875,14 +899,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
       ],
@@ -891,14 +916,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
       ],
@@ -907,14 +933,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
       ],
@@ -923,14 +950,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
       ],
@@ -939,14 +967,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
       ],
@@ -955,14 +984,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
       ],
@@ -971,14 +1001,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
       ],
@@ -987,14 +1018,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
       ],
@@ -1003,14 +1035,32 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
       ],
@@ -1019,14 +1069,32 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
       ],
@@ -1035,14 +1103,32 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
       ],
@@ -1051,14 +1137,15 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
       ],
@@ -1067,14 +1154,15 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
       ],
@@ -1083,14 +1171,15 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
       ],
@@ -1099,8 +1188,9 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@exodus/bytes": {
@@ -5801,6 +5891,38 @@
         "node": ">=14.16"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -5866,6 +5988,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/canvas-confetti": {
       "version": "1.9.0",
@@ -5945,13 +6075,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.11.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
-      "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -5970,7 +6100,6 @@
       "version": "18.2.48",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.48.tgz",
       "integrity": "sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -6017,7 +6146,6 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
@@ -7095,6 +7223,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -7352,6 +7489,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
@@ -7375,6 +7523,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -7587,40 +7743,45 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escalade": {
@@ -9280,6 +9441,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -10218,21 +10390,6 @@
         }
       }
     },
-    "node_modules/postcss-load-config/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -10385,6 +10542,44 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -11876,6 +12071,358 @@
         }
       }
     },
+    "node_modules/tsup/node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/tsup/node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -11898,6 +12445,43 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/tsup/node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
       }
     },
     "node_modules/tsup/node_modules/readdirp": {
@@ -11962,7 +12546,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -11983,9 +12567,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -12453,12 +13037,18 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Find and remove duplicate photos from Google Photos",
   "author": "Mack Talcott",
   "scripts": {
-    "build:gptk": "cd Google-Photos-Toolkit && npm run build && cp google_photos_toolkit.user.js ../scripts/google-photos-toolkit.user.js",
+    "build:gptk": "git submodule update --init && (test -d Google-Photos-Toolkit/node_modules || npm --prefix Google-Photos-Toolkit install --no-fund --no-audit) && cd Google-Photos-Toolkit && npm run build && cp google_photos_toolkit.user.js ../scripts/google-photos-toolkit.user.js",
     "copy:wasm": "cp node_modules/@mediapipe/tasks-vision/wasm/vision_wasm_internal.js scripts/ && cp node_modules/@mediapipe/tasks-vision/wasm/vision_wasm_internal.wasm scripts/",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -42,11 +42,13 @@
     "@types/react": "18.2.48",
     "@types/react-dom": "18.2.18",
     "@types/react-window": "^1.8.8",
+    "@vitejs/plugin-react": "^6.0.1",
     "@vitest/ui": "^4.1.2",
     "happy-dom": "^20.8.9",
     "jsdom": "^29.0.1",
     "prettier": "3.2.4",
     "typescript": "5.3.3",
+    "vite": "^8.0.7",
     "vitest": "^4.1.2"
   },
   "manifest": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/chrome": "0.0.258",
-    "@types/node": "20.11.5",
+    "@types/node": "^20.19.39",
     "@types/react": "18.2.48",
     "@types/react-dom": "18.2.18",
     "@types/react-window": "^1.8.8",

--- a/scripts/google-photos-commands.js
+++ b/scripts/google-photos-commands.js
@@ -74,6 +74,7 @@ async function getAllMediaItems(requestId, args) {
             duration: item.duration,
             isOwned: item.isOwned,
             fileName: item.descriptionShort || null,
+            productUrl: 'https://photos.google.com/photo/' + item.mediaKey,
           });
         }
       }

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -67,9 +67,9 @@ export default function App() {
     new Set()
   )
 
-  // Original overrides: groupId -> mediaKey the user marked as "original"
-  const [originalOverrides, setOriginalOverrides] = useState<
-    Record<string, string>
+  // Kept overrides: groupId -> Set of mediaKeys the user marked as "Keep"
+  const [keptOverrides, setKeptOverrides] = useState<
+    Record<string, Set<string>>
   >({})
 
   // Confirm dialog state
@@ -107,18 +107,29 @@ export default function App() {
       : []
   useEffect(() => {
     setSelectedGroupIds(new Set(groups.map((g) => g.id)))
-    setOriginalOverrides({})
+    setKeptOverrides({})
   }, [groups])
 
-  const getOriginal = useCallback(
-    (group: DuplicateGroup) =>
-      originalOverrides[group.id] || group.originalMediaKey,
-    [originalOverrides]
+  const getKept = useCallback(
+    (group: DuplicateGroup): Set<string> =>
+      keptOverrides[group.id] ?? new Set([group.originalMediaKey]),
+    [keptOverrides]
   )
 
-  const handleSetOriginal = useCallback(
-    (groupId: string, mediaKey: string) => {
-      setOriginalOverrides((prev) => ({ ...prev, [groupId]: mediaKey }))
+  const handleToggleKept = useCallback(
+    (group: DuplicateGroup, mediaKey: string) => {
+      setKeptOverrides((prev) => {
+        const current = prev[group.id] ?? new Set([group.originalMediaKey])
+        // Prevent removing the last kept item
+        if (current.has(mediaKey) && current.size === 1) return prev
+        const next = new Set(current)
+        if (next.has(mediaKey)) {
+          next.delete(mediaKey)
+        } else {
+          next.add(mediaKey)
+        }
+        return { ...prev, [group.id]: next }
+      })
     },
     []
   )
@@ -344,9 +355,9 @@ export default function App() {
     const mediaKeysToTrash: string[] = []
     for (const group of state.groups) {
       if (!selectedGroupIds.has(group.id)) continue
-      const original = getOriginal(group)
+      const keptSet = getKept(group)
       for (const key of group.mediaKeys) {
-        if (key === original) continue
+        if (keptSet.has(key)) continue
         const item = state.mediaItems[key]
         if (item?.dedupKey) {
           dedupKeys.push(item.dedupKey)
@@ -357,7 +368,7 @@ export default function App() {
 
     if (dedupKeys.length === 0) return
     setTrashConfirm({ dedupKeys, mediaKeysToTrash })
-  }, [state, selectedGroupIds, getOriginal])
+  }, [state, selectedGroupIds, getKept])
 
   const handleTrashConfirmed = useCallback(() => {
     if (!trashConfirm || state.status !== "results") return
@@ -440,10 +451,8 @@ export default function App() {
     state.status === "results"
       ? groups.reduce((sum, group) => {
           if (!selectedGroupIds.has(group.id)) return sum
-          const original = getOriginal(group)
-          return (
-            sum + group.mediaKeys.filter((k) => k !== original).length
-          )
+          const keptSet = getKept(group)
+          return sum + group.mediaKeys.filter((k) => !keptSet.has(k)).length
         }, 0)
       : 0
 
@@ -559,8 +568,8 @@ export default function App() {
               mediaItems={state.mediaItems}
               selectedGroupIds={selectedGroupIds}
               onToggleGroup={handleToggleGroup}
-              getOriginal={getOriginal}
-              onSetOriginal={handleSetOriginal}
+              getKept={getKept}
+              onToggleKept={handleToggleKept}
             />
           </>
         )}

--- a/tests/components/duplicate-groups.test.tsx
+++ b/tests/components/duplicate-groups.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Component tests for DuplicateGroups.
+ *
+ * Covers:
+ * - Multi-keep chip rendering (Keep / Trash / none)
+ * - Card click triggers onToggleKept
+ * - Zoom button opens the photo viewer modal
+ * - Zoom button does not trigger onToggleKept (stopPropagation)
+ */
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { ThemeProvider, createTheme } from "@mui/material/styles"
+import { DuplicateGroups } from "../../components/DuplicateGroups"
+import type { GpdMediaItem, DuplicateGroup } from "../../lib/types"
+
+// ============================================================
+// Mocks
+// ============================================================
+
+vi.mock("../../components/useBlobUrl", () => ({
+  useBlobUrl: (url: string | undefined) => (url ? `blob:${url}` : undefined),
+}))
+
+// Stub PhotoViewerModal so we can assert it opens without rendering the full dialog
+vi.mock("../../components/PhotoViewerModal", () => ({
+  PhotoViewerModal: ({ open, items, onClose }: { open: boolean; items: unknown[]; onClose: () => void }) =>
+    open ? (
+      <div data-testid="viewer-modal" data-item-count={items.length}>
+        <button onClick={onClose}>close-modal</button>
+      </div>
+    ) : null,
+}))
+
+// ============================================================
+// Helpers
+// ============================================================
+
+const theme = createTheme()
+
+function wrap(ui: React.ReactElement) {
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>)
+}
+
+function makeItem(mediaKey: string): GpdMediaItem {
+  return {
+    mediaKey,
+    dedupKey: `dk-${mediaKey}`,
+    thumb: `https://example.com/${mediaKey}`,
+    productUrl: `https://photos.google.com/photo/${mediaKey}`,
+    timestamp: Date.parse("2023-09-24"),
+    creationTimestamp: Date.parse("2023-09-24"),
+    resWidth: 1920,
+    resHeight: 1080,
+    fileName: `${mediaKey}.jpg`,
+    isOwned: true,
+  }
+}
+
+function makeGroup(id: string, ...mediaKeys: string[]): DuplicateGroup {
+  return { id, mediaKeys, originalMediaKey: mediaKeys[0], similarity: 0.99 }
+}
+
+const mediaItems: Record<string, GpdMediaItem> = {
+  img1: makeItem("img1"),
+  img2: makeItem("img2"),
+  img3: makeItem("img3"),
+}
+
+const group = makeGroup("g1", "img1", "img2", "img3")
+
+const defaultProps = {
+  groups: [group],
+  mediaItems,
+  selectedGroupIds: new Set(["g1"]),
+  onToggleGroup: vi.fn(),
+  getKept: (_g: DuplicateGroup) => new Set(["img1"]), // img1 kept by default
+  onToggleKept: vi.fn(),
+}
+
+// ============================================================
+// Chip rendering
+// ============================================================
+
+describe("DuplicateGroups — chip rendering", () => {
+  it("shows Keep chip only for kept item", () => {
+    wrap(<DuplicateGroups {...defaultProps} />)
+    const keepChips = screen.getAllByText("Keep")
+    expect(keepChips).toHaveLength(1)
+  })
+
+  it("shows Trash chips for non-kept items when group is selected", () => {
+    wrap(<DuplicateGroups {...defaultProps} />)
+    // img2 and img3 are not kept and group is selected
+    const trashChips = screen.getAllByText("Trash")
+    expect(trashChips).toHaveLength(2)
+  })
+
+  it("shows no Trash chips when group is deselected", () => {
+    wrap(
+      <DuplicateGroups
+        {...defaultProps}
+        selectedGroupIds={new Set()} // deselected
+      />
+    )
+    expect(screen.queryByText("Trash")).not.toBeInTheDocument()
+  })
+
+  it("shows multiple Keep chips when multiple items are kept", () => {
+    wrap(
+      <DuplicateGroups
+        {...defaultProps}
+        getKept={(_g) => new Set(["img1", "img2"])}
+      />
+    )
+    const keepChips = screen.getAllByText("Keep")
+    expect(keepChips).toHaveLength(2)
+    const trashChips = screen.getAllByText("Trash")
+    expect(trashChips).toHaveLength(1) // only img3
+  })
+})
+
+// ============================================================
+// Card click → onToggleKept
+// ============================================================
+
+describe("DuplicateGroups — card click", () => {
+  it("calls onToggleKept with the correct group and mediaKey", () => {
+    const onToggleKept = vi.fn()
+    wrap(<DuplicateGroups {...defaultProps} onToggleKept={onToggleKept} />)
+
+    // Click the second card (img2)
+    // Each card has a CardActionArea; we target the one containing img2.jpg
+    const img2Card = screen.getByTitle("img2.jpg").closest("button")
+    expect(img2Card).toBeTruthy()
+    fireEvent.click(img2Card!)
+
+    expect(onToggleKept).toHaveBeenCalledOnce()
+    expect(onToggleKept).toHaveBeenCalledWith(group, "img2")
+  })
+})
+
+// ============================================================
+// Zoom overlay → opens viewer modal
+// ============================================================
+
+describe("DuplicateGroups — zoom overlay", () => {
+  it("opens the photo viewer modal when zoom button is clicked", () => {
+    wrap(<DuplicateGroups {...defaultProps} />)
+    expect(screen.queryByTestId("viewer-modal")).not.toBeInTheDocument()
+
+    const zoomBtns = screen.getAllByRole("button", { name: /view full size/i })
+    fireEvent.click(zoomBtns[0])
+
+    expect(screen.getByTestId("viewer-modal")).toBeInTheDocument()
+  })
+
+  it("closes the viewer modal when onClose is called", () => {
+    wrap(<DuplicateGroups {...defaultProps} />)
+    const zoomBtns = screen.getAllByRole("button", { name: /view full size/i })
+    fireEvent.click(zoomBtns[0])
+
+    expect(screen.getByTestId("viewer-modal")).toBeInTheDocument()
+    fireEvent.click(screen.getByText("close-modal"))
+    expect(screen.queryByTestId("viewer-modal")).not.toBeInTheDocument()
+  })
+
+  it("opens the viewer for the correct item index", () => {
+    wrap(<DuplicateGroups {...defaultProps} />)
+    const zoomBtns = screen.getAllByRole("button", { name: /view full size/i })
+    // Click the second zoom button (index 1 → img2)
+    fireEvent.click(zoomBtns[1])
+
+    const modal = screen.getByTestId("viewer-modal")
+    expect(modal).toBeInTheDocument()
+    // The modal receives all 3 items (filtered from group.mediaKeys)
+    expect(modal).toHaveAttribute("data-item-count", "3")
+  })
+
+  it("zoom button click does NOT call onToggleKept", () => {
+    const onToggleKept = vi.fn()
+    wrap(<DuplicateGroups {...defaultProps} onToggleKept={onToggleKept} />)
+
+    const zoomBtns = screen.getAllByRole("button", { name: /view full size/i })
+    fireEvent.click(zoomBtns[0])
+
+    expect(onToggleKept).not.toHaveBeenCalled()
+  })
+})
+
+// ============================================================
+// Empty state
+// ============================================================
+
+describe("DuplicateGroups — empty state", () => {
+  it("shows no duplicates message when groups is empty", () => {
+    wrap(<DuplicateGroups {...defaultProps} groups={[]} />)
+    expect(screen.getByText(/no duplicates found/i)).toBeInTheDocument()
+  })
+})

--- a/tests/components/photo-viewer-modal.test.tsx
+++ b/tests/components/photo-viewer-modal.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * Component tests for PhotoViewerModal.
+ *
+ * We mock global fetch so useGroupBlobUrls resolves immediately with a
+ * stable blob URL, letting us test navigation and UI state synchronously.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { ThemeProvider, createTheme } from "@mui/material/styles"
+import { PhotoViewerModal } from "../../components/PhotoViewerModal"
+import type { GpdMediaItem } from "../../lib/types"
+
+// ============================================================
+// Mocks
+// ============================================================
+
+// Stub fetch → immediately resolves with a Blob so useGroupBlobUrls populates fast.
+// URL.createObjectURL is not available in happy-dom; stub it too.
+const mockObjectUrl = "blob:mock"
+vi.stubGlobal("URL", {
+  ...URL,
+  createObjectURL: () => mockObjectUrl,
+  revokeObjectURL: () => {},
+})
+
+vi.stubGlobal("fetch", (_url: string) =>
+  Promise.resolve({
+    ok: true,
+    blob: () => Promise.resolve(new Blob(["img"], { type: "image/jpeg" })),
+  } as Response)
+)
+
+// ============================================================
+// Helpers
+// ============================================================
+
+const theme = createTheme()
+
+function wrap(ui: React.ReactElement) {
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>)
+}
+
+function makeItem(mediaKey: string, overrides: Partial<GpdMediaItem> = {}): GpdMediaItem {
+  return {
+    mediaKey,
+    dedupKey: `dk-${mediaKey}`,
+    thumb: `https://example.com/${mediaKey}`,
+    productUrl: `https://photos.google.com/photo/${mediaKey}`,
+    timestamp: Date.parse("2023-09-24"),
+    creationTimestamp: Date.parse("2023-09-24"),
+    resWidth: 3024,
+    resHeight: 4032,
+    fileName: `${mediaKey}.jpg`,
+    isOwned: true,
+    ...overrides,
+  }
+}
+
+const items = [makeItem("img1"), makeItem("img2"), makeItem("img3")]
+
+const defaultProps = {
+  open: true,
+  items,
+  initialIndex: 0,
+  keptSet: new Set(["img1"]),
+  isGroupSelected: true,
+  onClose: vi.fn(),
+}
+
+// ============================================================
+// Rendering
+// ============================================================
+
+describe("PhotoViewerModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders the modal when open=true", () => {
+    wrap(<PhotoViewerModal {...defaultProps} />)
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+  })
+
+  it("does not render when items is empty", () => {
+    wrap(<PhotoViewerModal {...defaultProps} items={[]} />)
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("shows the filename in the header", () => {
+    wrap(<PhotoViewerModal {...defaultProps} />)
+    expect(screen.getByText(/img1\.jpg/)).toBeInTheDocument()
+  })
+
+  it("shows the counter for multi-item groups", () => {
+    wrap(<PhotoViewerModal {...defaultProps} />)
+    expect(screen.getByText(/1 \/ 3/)).toBeInTheDocument()
+  })
+
+  it("shows resolution and taken date in footer", () => {
+    wrap(<PhotoViewerModal {...defaultProps} />)
+    expect(screen.getByText(/3024×4032/)).toBeInTheDocument()
+    expect(screen.getByText(/Taken/)).toBeInTheDocument()
+  })
+})
+
+// ============================================================
+// Keep / Trash chip
+// ============================================================
+
+describe("PhotoViewerModal — chip display", () => {
+  it("shows Keep chip for a kept item", () => {
+    wrap(
+      <PhotoViewerModal
+        {...defaultProps}
+        keptSet={new Set(["img1"])}
+        isGroupSelected={true}
+      />
+    )
+    expect(screen.getByText("Keep")).toBeInTheDocument()
+    expect(screen.queryByText("Trash")).not.toBeInTheDocument()
+  })
+
+  it("shows Trash chip for a non-kept item in a selected group", () => {
+    wrap(
+      <PhotoViewerModal
+        {...defaultProps}
+        initialIndex={1}
+        keptSet={new Set(["img1"])} // img2 is not kept
+        isGroupSelected={true}
+      />
+    )
+    expect(screen.getByText("Trash")).toBeInTheDocument()
+    expect(screen.queryByText("Keep")).not.toBeInTheDocument()
+  })
+
+  it("shows no chip for non-kept item in a deselected group", () => {
+    wrap(
+      <PhotoViewerModal
+        {...defaultProps}
+        initialIndex={1}
+        keptSet={new Set(["img1"])}
+        isGroupSelected={false}
+      />
+    )
+    expect(screen.queryByText("Trash")).not.toBeInTheDocument()
+    expect(screen.queryByText("Keep")).not.toBeInTheDocument()
+  })
+})
+
+// ============================================================
+// Navigation
+// ============================================================
+
+describe("PhotoViewerModal — navigation", () => {
+  it("disables the Previous button on the first item", () => {
+    wrap(<PhotoViewerModal {...defaultProps} initialIndex={0} />)
+    const prevBtn = screen.getByRole("button", { name: /previous photo/i })
+    expect(prevBtn).toBeDisabled()
+  })
+
+  it("disables the Next button on the last item", () => {
+    wrap(<PhotoViewerModal {...defaultProps} initialIndex={2} />)
+    const nextBtn = screen.getByRole("button", { name: /next photo/i })
+    expect(nextBtn).toBeDisabled()
+  })
+
+  it("advances to the next item on Next click", () => {
+    wrap(<PhotoViewerModal {...defaultProps} initialIndex={0} />)
+    expect(screen.getByText(/1 \/ 3/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /next photo/i }))
+    expect(screen.getByText(/2 \/ 3/)).toBeInTheDocument()
+    expect(screen.getByText(/img2\.jpg/)).toBeInTheDocument()
+  })
+
+  it("goes back to the previous item on Previous click", () => {
+    wrap(<PhotoViewerModal {...defaultProps} initialIndex={2} />)
+    expect(screen.getByText(/3 \/ 3/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /previous photo/i }))
+    expect(screen.getByText(/2 \/ 3/)).toBeInTheDocument()
+  })
+
+  it("navigates forward with ArrowRight key", () => {
+    wrap(<PhotoViewerModal {...defaultProps} initialIndex={0} />)
+    fireEvent.keyDown(window, { key: "ArrowRight" })
+    expect(screen.getByText(/2 \/ 3/)).toBeInTheDocument()
+  })
+
+  it("navigates backward with ArrowLeft key", () => {
+    wrap(<PhotoViewerModal {...defaultProps} initialIndex={1} />)
+    fireEvent.keyDown(window, { key: "ArrowLeft" })
+    expect(screen.getByText(/1 \/ 3/)).toBeInTheDocument()
+  })
+
+  it("does not go below index 0 with ArrowLeft at first item", () => {
+    wrap(<PhotoViewerModal {...defaultProps} initialIndex={0} />)
+    fireEvent.keyDown(window, { key: "ArrowLeft" })
+    expect(screen.getByText(/1 \/ 3/)).toBeInTheDocument()
+  })
+
+  it("does not go above last index with ArrowRight at last item", () => {
+    wrap(<PhotoViewerModal {...defaultProps} initialIndex={2} />)
+    fireEvent.keyDown(window, { key: "ArrowRight" })
+    expect(screen.getByText(/3 \/ 3/)).toBeInTheDocument()
+  })
+})
+
+// ============================================================
+// Google Photos link
+// ============================================================
+
+describe("PhotoViewerModal — Google Photos link", () => {
+  it("shows the View in Google Photos link when productUrl is present", () => {
+    wrap(<PhotoViewerModal {...defaultProps} />)
+    const link = screen.getByRole("link", { name: /view in google photos/i })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute("href", "https://photos.google.com/photo/img1")
+    expect(link).toHaveAttribute("target", "_blank")
+  })
+
+  it("does not show the link when productUrl is absent", () => {
+    const itemsNoUrl = items.map((item) => ({ ...item, productUrl: undefined }))
+    wrap(<PhotoViewerModal {...defaultProps} items={itemsNoUrl} />)
+    expect(screen.queryByRole("link", { name: /view in google photos/i })).not.toBeInTheDocument()
+  })
+})
+
+// ============================================================
+// Close button
+// ============================================================
+
+describe("PhotoViewerModal — close", () => {
+  it("calls onClose when the close button is clicked", () => {
+    const onClose = vi.fn()
+    wrap(<PhotoViewerModal {...defaultProps} onClose={onClose} />)
+    fireEvent.click(screen.getByRole("button", { name: /close photo viewer/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/lib/multi-keep.test.ts
+++ b/tests/lib/multi-keep.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for the multi-keep state logic.
+ *
+ * The keep-toggle logic lives as an inline setState updater in app.tsx.
+ * We extract and test it here as a pure function to verify all the edge cases.
+ */
+import { describe, it, expect } from "vitest"
+import type { DuplicateGroup } from "../../lib/types"
+
+// ============================================================
+// Pure logic extracted from handleToggleKept in app.tsx
+// ============================================================
+
+type KeptOverrides = Record<string, Set<string>>
+
+function getKept(group: DuplicateGroup, keptOverrides: KeptOverrides): Set<string> {
+  return keptOverrides[group.id] ?? new Set([group.originalMediaKey])
+}
+
+function applyToggleKept(
+  prev: KeptOverrides,
+  group: DuplicateGroup,
+  mediaKey: string
+): KeptOverrides {
+  const current = prev[group.id] ?? new Set([group.originalMediaKey])
+  if (current.has(mediaKey) && current.size === 1) return prev
+  const next = new Set(current)
+  if (next.has(mediaKey)) {
+    next.delete(mediaKey)
+  } else {
+    next.add(mediaKey)
+  }
+  return { ...prev, [group.id]: next }
+}
+
+// ============================================================
+// Fixtures
+// ============================================================
+
+function makeGroup(id: string, ...mediaKeys: string[]): DuplicateGroup {
+  return { id, mediaKeys, originalMediaKey: mediaKeys[0], similarity: 0.99 }
+}
+
+const g1 = makeGroup("g1", "img1", "img2", "img3")
+
+// ============================================================
+// getKept
+// ============================================================
+
+describe("getKept", () => {
+  it("returns a Set with the originalMediaKey when no override exists", () => {
+    const result = getKept(g1, {})
+    expect(result).toEqual(new Set(["img1"]))
+  })
+
+  it("returns the override set when one exists", () => {
+    const overrides: KeptOverrides = { g1: new Set(["img2", "img3"]) }
+    const result = getKept(g1, overrides)
+    expect(result).toEqual(new Set(["img2", "img3"]))
+  })
+
+  it("does not affect other groups", () => {
+    const g2 = makeGroup("g2", "img4", "img5")
+    const overrides: KeptOverrides = { g1: new Set(["img2"]) }
+    const result = getKept(g2, overrides)
+    expect(result).toEqual(new Set(["img4"]))
+  })
+})
+
+// ============================================================
+// applyToggleKept — adding items
+// ============================================================
+
+describe("applyToggleKept — adding", () => {
+  it("adds a non-kept item to the kept set", () => {
+    const prev: KeptOverrides = {}
+    const next = applyToggleKept(prev, g1, "img2")
+    expect(next["g1"]).toEqual(new Set(["img1", "img2"]))
+  })
+
+  it("can keep all items in a group", () => {
+    let overrides: KeptOverrides = {}
+    overrides = applyToggleKept(overrides, g1, "img2")
+    overrides = applyToggleKept(overrides, g1, "img3")
+    expect(overrides["g1"]).toEqual(new Set(["img1", "img2", "img3"]))
+  })
+
+  it("does not add duplicate entries", () => {
+    const overrides: KeptOverrides = { g1: new Set(["img1", "img2"]) }
+    const next = applyToggleKept(overrides, g1, "img2")
+    // img2 was already kept → toggle removes it
+    expect(next["g1"]).toEqual(new Set(["img1"]))
+  })
+})
+
+// ============================================================
+// applyToggleKept — removing items
+// ============================================================
+
+describe("applyToggleKept — removing", () => {
+  it("removes a kept item when toggled off", () => {
+    const prev: KeptOverrides = { g1: new Set(["img1", "img2"]) }
+    const next = applyToggleKept(prev, g1, "img2")
+    expect(next["g1"]).toEqual(new Set(["img1"]))
+  })
+
+  it("does NOT remove the last kept item (guard)", () => {
+    const prev: KeptOverrides = { g1: new Set(["img1"]) }
+    const next = applyToggleKept(prev, g1, "img1")
+    // Should return prev unchanged
+    expect(next).toBe(prev)
+    expect(next["g1"]).toEqual(new Set(["img1"]))
+  })
+
+  it("does NOT remove the default kept item when it is the only one", () => {
+    // No override → default is {img1}; trying to remove img1 should be a no-op
+    const prev: KeptOverrides = {}
+    const next = applyToggleKept(prev, g1, "img1")
+    expect(next).toBe(prev)
+  })
+})
+
+// ============================================================
+// applyToggleKept — isolation between groups
+// ============================================================
+
+describe("applyToggleKept — group isolation", () => {
+  it("only mutates the target group's override", () => {
+    const g2 = makeGroup("g2", "img4", "img5")
+    const prev: KeptOverrides = { g2: new Set(["img4"]) }
+    const next = applyToggleKept(prev, g1, "img2")
+    // g1 gains an override
+    expect(next["g1"]).toEqual(new Set(["img1", "img2"]))
+    // g2 is unchanged
+    expect(next["g2"]).toEqual(new Set(["img4"]))
+  })
+})
+
+// ============================================================
+// duplicateCount logic
+// ============================================================
+
+describe("duplicateCount", () => {
+  function computeDuplicateCount(
+    groups: DuplicateGroup[],
+    selectedGroupIds: Set<string>,
+    keptOverrides: KeptOverrides
+  ): number {
+    return groups.reduce((sum, group) => {
+      if (!selectedGroupIds.has(group.id)) return sum
+      const keptSet = getKept(group, keptOverrides)
+      return sum + group.mediaKeys.filter((k) => !keptSet.has(k)).length
+    }, 0)
+  }
+
+  it("counts non-kept items in selected groups", () => {
+    const groups = [makeGroup("g1", "img1", "img2", "img3")]
+    const count = computeDuplicateCount(groups, new Set(["g1"]), {})
+    // img1 is kept by default; img2, img3 are trash
+    expect(count).toBe(2)
+  })
+
+  it("returns 0 for deselected groups", () => {
+    const groups = [makeGroup("g1", "img1", "img2")]
+    const count = computeDuplicateCount(groups, new Set(), {})
+    expect(count).toBe(0)
+  })
+
+  it("accounts for multi-keep overrides", () => {
+    const groups = [makeGroup("g1", "img1", "img2", "img3")]
+    const overrides: KeptOverrides = { g1: new Set(["img1", "img2"]) }
+    const count = computeDuplicateCount(groups, new Set(["g1"]), overrides)
+    // img1 + img2 kept, img3 trash
+    expect(count).toBe(1)
+  })
+
+  it("counts 0 when all items are kept", () => {
+    const groups = [makeGroup("g1", "img1", "img2")]
+    const overrides: KeptOverrides = { g1: new Set(["img1", "img2"]) }
+    const count = computeDuplicateCount(groups, new Set(["g1"]), overrides)
+    expect(count).toBe(0)
+  })
+
+  it("aggregates across multiple groups", () => {
+    const g2 = makeGroup("g2", "img3", "img4")
+    const groups = [g1, g2]
+    const count = computeDuplicateCount(groups, new Set(["g1", "g2"]), {})
+    // g1: img1 kept, img2+img3 trash (2); g2: img3 kept, img4 trash (1)
+    expect(count).toBe(3)
+  })
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig } from "vitest/config"
+import react from "@vitejs/plugin-react"
 import path from "path"
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     environment: "happy-dom",
     globals: true,
+    setupFiles: ["tests/setup.ts"],
     include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
     exclude: ["tests/e2e/**"],
   },


### PR DESCRIPTION
## Summary

- **Multi-keep** (closes #9, closes #56): replaces the single-keep model with a set-based approach. Any subset of photos in a group can be marked Keep; clicking a card toggles it in/out of the kept set. A guard prevents the set from ever becoming empty. The `originalMediaKey` from the algorithm seeds the default.
- **Photo viewer modal**: hovering a thumbnail reveals a zoom icon overlay. Clicking it opens a fullscreen dialog with:
  - All group images preloaded in parallel (no per-image fetch on navigation)
  - Left/right navigation via buttons or arrow keys; disabled (not hidden) at boundaries
  - Keep/Trash chip reflecting live state
  - Resolution, taken date, uploaded date metadata
  - "View in Google Photos" link (conditional on `productUrl`)
  - Slide animation on the counter when switching photos
- **Tests**: 80 Vitest + @testing-library/react tests covering multi-keep logic, `PhotoViewerModal`, and `DuplicateGroups`
- **`useBlobUrl`** extracted to a standalone hook; stale-closure cleanup bug fixed
- **`build:gptk`** self-initializes the GPTK submodule so fresh worktrees work without manual steps

## Test plan

- [x] `npm test` — all 80 tests pass
- [x] Run dev build; open a duplicate group with 3+ photos
- [x] Click a second photo card — both show blue border + Keep chip; click again to revert
- [x] Try to un-keep the only kept photo — should have no effect
- [x] ActionBar duplicate count updates correctly as kept set changes
- [x] Trash operation skips all kept photos
- [x] Hover a card — zoom icon appears; click it — modal opens
- [x] Left/right buttons and arrow keys navigate; disabled at boundaries; Escape closes
- [x] Counter slides in the correct direction
- [x] "View in Google Photos" link opens new tab
- [ ] Load cached scan data (pre-`productUrl`) — link absent, no errors