### PR TITLE
Increase confetti particleCount and spread

### DIFF
--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -440,8 +440,8 @@ export default function App() {
   useEffect(() => {
     if (!undoData) return
     confetti({
-      particleCount: 120,
-      spread: 70,
+      particleCount: 200,
+      spread: 100,
       origin: { y: 0.7 },
     })
   }, [undoData])


### PR DESCRIPTION
Increases confetti `particleCount` from 120 → 200 and `spread` from 70 → 100 for a fuller celebration effect.