### PR TITLE
Results loading UI polish

### DIFF
--- a/components/DuplicateGroups.tsx
+++ b/components/DuplicateGroups.tsx
@@ -8,6 +8,7 @@ import Checkbox from "@mui/material/Checkbox"
 import Chip from "@mui/material/Chip"
 import IconButton from "@mui/material/IconButton"
 import Paper from "@mui/material/Paper"
+import Skeleton from "@mui/material/Skeleton"
 import Typography from "@mui/material/Typography"
 import OpenInFullIcon from "@mui/icons-material/OpenInFull"
 import { useBlobUrl } from "./useBlobUrl"
@@ -15,11 +16,14 @@ import { PhotoViewerModal } from "./PhotoViewerModal"
 import type { GpdMediaItem, DuplicateGroup } from "../lib/types"
 
 function ThumbnailImage({ src, alt }: { src: string; alt: string }) {
-  const blobUrl = useBlobUrl(src)
+  const { blobUrl, loading } = useBlobUrl(src)
+  if (loading || !blobUrl) {
+    return <Skeleton variant="rectangular" height={120} animation="wave" />
+  }
   return (
     <CardMedia
       component="img"
-      image={blobUrl || ""}
+      image={blobUrl}
       alt={alt}
       sx={{ height: 120, objectFit: "cover" }}
     />

--- a/components/useBlobUrl.ts
+++ b/components/useBlobUrl.ts
@@ -4,23 +4,36 @@ import { useState, useEffect } from "react"
  * Fetch a URL via fetch() (which uses extension host_permissions + cookies)
  * and return a blob URL that <img> can display. Revokes the blob URL on cleanup.
  */
-export function useBlobUrl(url: string | undefined): string | undefined {
+export function useBlobUrl(url: string | undefined): {
+  blobUrl: string | undefined
+  loading: boolean
+} {
   const [blobUrl, setBlobUrl] = useState<string>()
+  const [loading, setLoading] = useState(!!url)
 
   useEffect(() => {
-    if (!url) return
+    if (!url) {
+      setLoading(false)
+      return
+    }
     let revoked = false
     let objectUrl: string | undefined
 
+    setLoading(true)
     fetch(url, { credentials: "include" })
       .then((r) => (r.ok ? r.blob() : null))
       .then((blob) => {
-        if (blob && !revoked) {
-          objectUrl = URL.createObjectURL(blob)
-          setBlobUrl(objectUrl)
+        if (!revoked) {
+          if (blob) {
+            objectUrl = URL.createObjectURL(blob)
+            setBlobUrl(objectUrl)
+          }
+          setLoading(false)
         }
       })
-      .catch(() => {})
+      .catch(() => {
+        if (!revoked) setLoading(false)
+      })
 
     return () => {
       revoked = true
@@ -28,5 +41,5 @@ export function useBlobUrl(url: string | undefined): string | undefined {
     }
   }, [url])
 
-  return blobUrl
+  return { blobUrl, loading }
 }

--- a/lib/app-reducer.ts
+++ b/lib/app-reducer.ts
@@ -39,7 +39,6 @@ export type AppState =
       mediaItems: Record<string, GpdMediaItem>
       groups: DuplicateGroup[]
       totalItems: number
-      trashedCount: number
       totalToTrash: number
       accountEmail?: string
     }
@@ -63,7 +62,6 @@ export type AppAction =
       groups: DuplicateGroup[]
       totalItems: number
     }
-  | { type: "TRASH_PROGRESS"; trashedCount: number }
   | { type: "TRASH_COMPLETE"; trashedKeys: string[] }
   | { type: "TRASH_ERROR"; error: string }
   | {
@@ -159,14 +157,9 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         mediaItems: action.mediaItems,
         groups: action.groups,
         totalItems: action.totalItems,
-        trashedCount: 0,
         totalToTrash: action.totalToTrash,
         accountEmail: "accountEmail" in state ? state.accountEmail : undefined,
       }
-
-    case "TRASH_PROGRESS":
-      if (state.status !== "trashing") return state
-      return { ...state, trashedCount: action.trashedCount }
 
     case "TRASH_COMPLETE": {
       if (state.status !== "trashing") return state

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -585,7 +585,7 @@ export default function App() {
             }}>
             <CircularProgress size={28} />
             <Typography variant="body2" color="text.secondary">
-              Moving items to trash… {state.trashedCount}/{state.totalToTrash}
+              Moving items to trash…
             </Typography>
           </Box>
         )}

--- a/tests/lib/app-reducer.test.ts
+++ b/tests/lib/app-reducer.test.ts
@@ -56,7 +56,6 @@ const trashingState: AppState = {
   mediaItems,
   groups,
   totalItems: 4,
-  trashedCount: 0,
   totalToTrash: 2,
 }
 
@@ -185,7 +184,6 @@ describe("TRASH_COMPLETE", () => {
       mediaItems,
       groups: [threeItemGroup],
       totalItems: 3,
-      trashedCount: 0,
       totalToTrash: 1,
     }
     const next = appReducer(state, {


### PR DESCRIPTION
## Summary

- **Thumbnail skeletons on load**: `useBlobUrl` now tracks a `loading` state and returns `{ blobUrl, loading }`. `ThumbnailImage` renders an MUI wave skeleton while the blob URL is being fetched, so broken image icons no longer appear when results first load.
- **Remove trash progress counter**: The trashing screen no longer shows `X/Y` — `trashItems` is a single batch API call with no intermediate progress events, so the counter was always stuck at `0/N`. Removed the dead `trashedCount` field and `TRASH_PROGRESS` action from the reducer; `totalToTrash` is kept.

## Test plan

- [x] Run a scan and verify thumbnails show skeletons while loading, then fade in correctly
- [x] Move duplicates to trash and verify the spinner shows without a counter
- [x] `npm test` — all 80 unit tests pass