### PR TITLE
Add IndexedDB embedding cache

### DIFF
--- a/components/DuplicateGroups.tsx
+++ b/components/DuplicateGroups.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useState, useRef, useEffect } from "react"
 import Box from "@mui/material/Box"
 import Card from "@mui/material/Card"
 import CardActionArea from "@mui/material/CardActionArea"
@@ -43,6 +43,22 @@ export function DuplicateGroups({
   getKept,
   onToggleKept,
 }: DuplicateGroupsProps) {
+  // Measure time from first non-empty groups render to commit
+  const renderLoggedRef = useRef(false)
+  const renderStartRef = useRef<number | null>(null)
+  if (groups.length > 0 && !renderLoggedRef.current && renderStartRef.current === null) {
+    renderStartRef.current = performance.now()
+  }
+  useEffect(() => {
+    if (renderLoggedRef.current || renderStartRef.current === null || groups.length === 0) return
+    renderLoggedRef.current = true
+    const elapsed = performance.now() - renderStartRef.current
+    const totalThumbnails = groups.reduce((s, g) => s + g.mediaKeys.length, 0)
+    console.log(
+      `[GPD perf] Results render: ${elapsed.toFixed(0)}ms for ${groups.length} groups, ${totalThumbnails} thumbnails`
+    )
+  })
+
   const [viewerState, setViewerState] = useState<{
     group: DuplicateGroup
     index: number
@@ -269,3 +285,4 @@ export function DuplicateGroups({
     </Box>
   )
 }
+

--- a/lib/app-reducer.ts
+++ b/lib/app-reducer.ts
@@ -47,7 +47,7 @@ export type AppState =
 export type AppAction =
   | { type: "HEALTH_CHECK_RESULT"; payload: HealthCheckResultMessage }
   | { type: "SCAN_STARTED"; requestId: string; hasGptk: boolean; accountEmail?: string }
-  | { type: "SCAN_PROGRESS"; payload: GptkProgressMessage; phase?: ScanPhase }
+  | { type: "SCAN_PROGRESS"; payload: GptkProgressMessage; phase?: ScanPhase; totalItems?: number }
   | { type: "SCAN_MEDIA_FETCHED"; mediaItems: GpdMediaItem[] }
   | {
       type: "SCAN_COMPLETE"
@@ -124,6 +124,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         ...state,
         ...(action.phase !== undefined ? { phase: action.phase } : {}),
         itemsProcessed: action.payload.itemsProcessed,
+        ...(action.totalItems !== undefined ? { totalEstimate: action.totalItems } : {}),
         message: action.payload.message || state.message,
       }
 

--- a/lib/debug.ts
+++ b/lib/debug.ts
@@ -1,0 +1,29 @@
+// Debug logging utility.
+// Enable at runtime in the extension console:
+//   localStorage.setItem("gpd:debug", "1"); location.reload()
+// Disable:
+//   localStorage.removeItem("gpd:debug"); location.reload()
+//
+// Or enable for a single session without reload:
+//   window.__gpdDebug = true
+
+type LogLevel = "log" | "warn" | "error"
+
+function isEnabled(): boolean {
+  try {
+    return !!(localStorage.getItem("gpd:debug") || (window as any).__gpdDebug)
+  } catch {
+    return false
+  }
+}
+
+function dbg(level: LogLevel, tag: string, ...args: unknown[]): void {
+  if (!isEnabled()) return
+  console[level](`[GPD:${tag}]`, ...args)
+}
+
+export const debug = {
+  log: (tag: string, ...args: unknown[]) => dbg("log", tag, ...args),
+  warn: (tag: string, ...args: unknown[]) => dbg("warn", tag, ...args),
+  error: (tag: string, ...args: unknown[]) => dbg("error", tag, ...args),
+}

--- a/lib/duplicate-detector.ts
+++ b/lib/duplicate-detector.ts
@@ -8,6 +8,7 @@
 
 import { ImageEmbedder } from "@mediapipe/tasks-vision"
 import type { GpdMediaItem, DuplicateGroup } from "./types"
+import { EmbeddingCache } from "./embedding-cache"
 
 const MODEL_URL =
   "https://storage.googleapis.com/mediapipe-models/image_embedder/mobilenet_v3_large/float32/latest/mobilenet_v3_large.tflite"
@@ -38,21 +39,119 @@ export async function detectDuplicates(
   console.log(`[GPD] detectDuplicates: ${mediaItems.length} items → ${candidates.length} candidates`)
   if (candidates.length < 2) return []
 
-  // Step 1: Download thumbnails
-  const blobs = await fetchThumbnails(candidates, onProgress, signal)
+  const t0 = performance.now()
+
+  // Load cached embeddings from IndexedDB
+  let cache: EmbeddingCache | null = null
+  // allEmbeddings[i] holds the embedding for candidates[i], or null if not yet computed
+  let allEmbeddings: (Float32Array | null)[]
+  try {
+    cache = await EmbeddingCache.open()
+    allEmbeddings = await cache.getMany(candidates.map((c) => c.mediaKey))
+  } catch (e) {
+    console.warn("[GPD] Embedding cache unavailable, falling back to full scan:", e)
+    allEmbeddings = new Array(candidates.length).fill(null)
+  }
+
+  const cachedCount = allEmbeddings.filter(Boolean).length
+  if (cache) {
+    try {
+      const totalEntries = await cache.count()
+      const estimatedMB = (totalEntries * 5120 / 1024 / 1024).toFixed(1) // ~5KB/entry
+      console.log(`[GPD] Embedding cache: ${cachedCount}/${candidates.length} hits (${totalEntries} entries, ~${estimatedMB}MB)`)
+    } catch {
+      console.log(`[GPD] Embedding cache: ${cachedCount}/${candidates.length} hits`)
+    }
+  } else {
+    console.log(`[GPD] Embedding cache: ${cachedCount}/${candidates.length} hits`)
+  }
+
+  // Identify candidates that need thumbnails fetched + embeddings computed
+  const uncachedIndices: number[] = [] // indices into candidates[]
+  const uncachedCandidates: GpdMediaItem[] = []
+  for (let i = 0; i < candidates.length; i++) {
+    if (!allEmbeddings[i]) {
+      uncachedIndices.push(i)
+      uncachedCandidates.push(candidates[i])
+    }
+  }
+
+  // Step 1: Download thumbnails (only for uncached items)
+  let blobs: (Blob | null)[] = []
+  if (uncachedCandidates.length > 0) {
+    blobs = await fetchThumbnails(uncachedCandidates, onProgress, signal)
+  } else {
+    // All cached — skip thumbnail phase entirely
+    onProgress?.({ phase: "downloading_thumbnails", current: 0, total: 0 })
+  }
+  const t1 = performance.now()
+  console.log(
+    `[GPD perf] Step 1 (thumbnails): ${((t1 - t0) / 1000).toFixed(1)}s` +
+    ` (${uncachedCandidates.length} uncached, ${cachedCount} from cache)`
+  )
 
   signal?.throwIfAborted()
 
-  // Step 2: Compute embeddings
-  const { embeddings, validIndices } = await computeEmbeddings(
-    blobs,
-    onProgress,
-    signal
-  )
+  // Step 2: Compute embeddings for uncached items, then persist to cache
+  if (uncachedCandidates.length > 0) {
+    const { embeddings: newEmbeddings, validIndices: newValidIndices } =
+      await computeEmbeddings(blobs, onProgress, signal)
+
+    // Map new embeddings back to their original candidate positions
+    const toCache: { mediaKey: string; embedding: Float32Array }[] = []
+    for (let j = 0; j < newValidIndices.length; j++) {
+      const uncachedPos = newValidIndices[j] // index into uncachedCandidates
+      const origPos = uncachedIndices[uncachedPos] // index into candidates
+      allEmbeddings[origPos] = newEmbeddings[j]
+      toCache.push({ mediaKey: candidates[origPos].mediaKey, embedding: newEmbeddings[j] })
+    }
+
+    if (cache && toCache.length > 0) {
+      try {
+        await cache.setMany(toCache)
+        console.log(`[GPD] Cached ${toCache.length} new embeddings`)
+      } catch (e) {
+        console.warn("[GPD] Failed to persist embeddings to cache:", e)
+      }
+    }
+  } else {
+    // All cached — fire a synthetic progress event so the UI advances
+    onProgress?.({ phase: "computing_embeddings", current: candidates.length, total: candidates.length })
+  }
+
+  const t2 = performance.now()
+  console.log(`[GPD perf] Step 2 (model + embeddings): ${((t2 - t1) / 1000).toFixed(1)}s`)
+
+  // Build final flat embedding arrays (only items that have a valid embedding)
+  const embeddings: Float32Array[] = []
+  const validIndices: number[] = []
+  for (let i = 0; i < allEmbeddings.length; i++) {
+    if (allEmbeddings[i]) {
+      embeddings.push(allEmbeddings[i]!)
+      validIndices.push(i)
+    }
+  }
+
   if (embeddings.length < 2) return []
 
   // Step 3: Community detection (synchronous — no progress event)
   const indexGroups = communityDetection(embeddings, threshold)
+
+  const t3 = performance.now()
+  console.log(`[GPD perf] Step 3 (community detection): ${((t3 - t2) / 1000).toFixed(1)}s`)
+  console.log(`[GPD perf] Total: ${((t3 - t0) / 1000).toFixed(1)}s`)
+
+  // Evict stale cache entries for items no longer in the library
+  if (cache) {
+    try {
+      const keepKeys = new Set(candidates.map((c) => c.mediaKey))
+      const evicted = await cache.evictExcept(keepKeys)
+      if (evicted > 0) console.log(`[GPD] Evicted ${evicted} stale cache entries`)
+    } catch (e) {
+      console.warn("[GPD] Cache eviction failed:", e)
+    }
+    cache.close()
+  }
 
   // Map indices back to media items and build DuplicateGroup objects
   const groups: DuplicateGroup[] = indexGroups.map((indices, i) => {
@@ -157,9 +256,11 @@ async function computeEmbeddings(
   // Fetch model as ArrayBuffer — modelAssetPath fails in extension context
   let modelBuffer: ArrayBuffer
   try {
+    const tModel0 = performance.now()
     const resp = await fetch(MODEL_URL)
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
     modelBuffer = await resp.arrayBuffer()
+    console.log(`[GPD perf] Model download: ${((performance.now() - tModel0) / 1000).toFixed(1)}s (${(modelBuffer.byteLength / 1024 / 1024).toFixed(1)}MB)`)
   } catch (e) {
     throw new Error(`Failed to download model: ${e instanceof Error ? e.message : e}`)
   }
@@ -201,7 +302,8 @@ async function computeEmbeddings(
       // Using the canvas approach for browser compatibility
       const result = embedder.embed(imageData)
       if (result?.embeddings?.[0]?.floatEmbedding) {
-        embeddings.push(new Float32Array(result.embeddings[0].floatEmbedding))
+        const vec = new Float32Array(result.embeddings[0].floatEmbedding)
+        embeddings.push(vec)
         validIndices.push(i)
       }
 
@@ -377,3 +479,5 @@ export function topK(
 
   return { values, indices }
 }
+
+

--- a/lib/embedding-cache.ts
+++ b/lib/embedding-cache.ts
@@ -1,0 +1,108 @@
+// Embedding cache using IndexedDB.
+// Stores Float32Array embeddings keyed by mediaKey, persisted across scans.
+// Typical size: ~5KB/item × 48k items = ~238MB for a large library.
+
+const DB_NAME = "gpd-cache"
+const DB_VERSION = 1
+const STORE_NAME = "embeddings"
+
+interface EmbeddingRecord {
+  mediaKey: string
+  embedding: Float32Array
+}
+
+export class EmbeddingCache {
+  private db: IDBDatabase
+
+  private constructor(db: IDBDatabase) {
+    this.db = db
+  }
+
+  static async open(): Promise<EmbeddingCache> {
+    return new Promise((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, DB_VERSION)
+      req.onupgradeneeded = (e) => {
+        const db = (e.target as IDBOpenDBRequest).result
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME, { keyPath: "mediaKey" })
+        }
+      }
+      req.onsuccess = () => resolve(new EmbeddingCache(req.result))
+      req.onerror = () => reject(req.error)
+    })
+  }
+
+  /** Retrieve embeddings for a batch of mediaKeys. Returns null for cache misses. */
+  async getMany(mediaKeys: string[]): Promise<(Float32Array | null)[]> {
+    if (mediaKeys.length === 0) return []
+    return new Promise((resolve, reject) => {
+      const tx = this.db.transaction(STORE_NAME, "readonly")
+      const store = tx.objectStore(STORE_NAME)
+      const results: (Float32Array | null)[] = new Array(mediaKeys.length).fill(null)
+      let pending = mediaKeys.length
+
+      mediaKeys.forEach((key, i) => {
+        const req = store.get(key)
+        req.onsuccess = () => {
+          results[i] = (req.result as EmbeddingRecord | undefined)?.embedding ?? null
+          if (--pending === 0) resolve(results)
+        }
+        req.onerror = () => {
+          if (--pending === 0) resolve(results)
+        }
+      })
+    })
+  }
+
+  /** Persist a batch of embeddings. Overwrites existing entries. */
+  async setMany(records: { mediaKey: string; embedding: Float32Array }[]): Promise<void> {
+    if (records.length === 0) return
+    return new Promise((resolve, reject) => {
+      const tx = this.db.transaction(STORE_NAME, "readwrite")
+      const store = tx.objectStore(STORE_NAME)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+      for (const record of records) {
+        store.put(record)
+      }
+    })
+  }
+
+  /** Delete stale entries no longer in the current library. */
+  async evictExcept(keepKeys: Set<string>): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const tx = this.db.transaction(STORE_NAME, "readwrite")
+      const store = tx.objectStore(STORE_NAME)
+      const req = store.openKeyCursor()
+      const toDelete: string[] = []
+
+      req.onsuccess = () => {
+        const cursor = req.result
+        if (cursor) {
+          if (!keepKeys.has(cursor.key as string)) {
+            toDelete.push(cursor.key as string)
+          }
+          cursor.continue()
+        } else {
+          for (const key of toDelete) store.delete(key)
+        }
+      }
+      tx.oncomplete = () => resolve(toDelete.length)
+      tx.onerror = () => reject(tx.error)
+    })
+  }
+
+  /** Return the total number of entries in the cache. */
+  async count(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const tx = this.db.transaction(STORE_NAME, "readonly")
+      const req = tx.objectStore(STORE_NAME).count()
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error)
+    })
+  }
+
+  close(): void {
+    this.db.close()
+  }
+}

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -19,6 +19,7 @@ import CloseIcon from "@mui/icons-material/Close"
 import { ThemeProvider } from "@mui/material/styles"
 import theme from "../lib/theme"
 import { APP_ID } from "../lib/types"
+import { debug } from "../lib/debug"
 import { detectDuplicates } from "../lib/duplicate-detector"
 import type { DetectionProgress } from "../lib/duplicate-detector"
 import { appReducer } from "../lib/app-reducer"
@@ -54,6 +55,8 @@ function sendToServiceWorker(message: AppMessage): void {
 // ============================================================
 // App component
 // ============================================================
+
+const EMPTY_GROUPS: DuplicateGroup[] = []
 
 export default function App() {
   const [state, dispatch] = useReducer(appReducer, { status: "connecting" })
@@ -104,7 +107,7 @@ export default function App() {
   const groups =
     state.status === "results" || state.status === "trashing"
       ? state.groups
-      : []
+      : EMPTY_GROUPS
   useEffect(() => {
     setSelectedGroupIds(new Set(groups.map((g) => g.id)))
     setKeptOverrides({})
@@ -213,12 +216,15 @@ export default function App() {
             dispatch({ type: "GP_TAB_CLOSED" })
           }
           break
-        case "gptkProgress":
-          dispatch({
-            type: "SCAN_PROGRESS",
-            payload: message as GptkProgressMessage,
-          })
+        case "gptkProgress": {
+          const prog = message as GptkProgressMessage
+          // Only apply GPTK batch counts during the fetching phase — stale messages
+          // can arrive after SCAN_MEDIA_FETCHED fires (while IndexedDB is opening)
+          // and would overwrite thumbnail/embedding progress with irrelevant numbers.
+          if (state.status === "scanning" && state.phase !== "fetching") break
+          dispatch({ type: "SCAN_PROGRESS", payload: prog })
           break
+        }
       }
     }
 
@@ -241,6 +247,7 @@ export default function App() {
             dispatch({
               type: "SCAN_PROGRESS",
               phase: progress.phase,
+              totalItems: progress.total > 0 ? progress.total : undefined,
               payload: {
                 app: APP_ID,
                 action: "gptkProgress",


### PR DESCRIPTION
## Summary

- Adds `EmbeddingCache` (`lib/embedding-cache.ts`) — persists Float32Array embeddings in IndexedDB keyed by `mediaKey`, so thumbnails and MediaPipe inference are skipped for items already seen. Includes eviction of stale entries for items no longer in the library.
- Fixes scan progress display jumping caused by (a) GPTK batch-count messages landing after `SCAN_MEDIA_FETCHED` fires and overwriting thumbnail/embedding progress, and (b) `totalEstimate` staying frozen at full library size while cached runs only process a small uncached subset.
- Adds `lib/debug.ts` — toggleable debug logger for future diagnostic use (`localStorage.setItem("gpd:debug","1")` in the extension console).

## Test plan

- [ ] First scan: verify all items are processed, embeddings persisted (check console for `[GPD] Cached N new embeddings`)
- [ ] Second scan: verify cache hits logged (`[GPD] Embedding cache: N/N hits`) and thumbnail/embedding steps are skipped or fast
- [ ] Partial cache: delete a few entries from IndexedDB, rescan — only missing items should be re-fetched
- [ ] Progress bar stays monotonically increasing within each phase; no jumps back to large GPTK counts during thumbnail/embedding phases
- [ ] Cancel mid-scan, rescan — no errors from stale cache state
- [ ] Large library: confirm eviction log appears if library items were removed since last scan