### PR TITLE
Add smart scan mode (timestamp bucketing + instant detection)

### DIFF
--- a/components/ScanConfig.tsx
+++ b/components/ScanConfig.tsx
@@ -1,9 +1,15 @@
+import Accordion from "@mui/material/Accordion"
+import AccordionDetails from "@mui/material/AccordionDetails"
+import AccordionSummary from "@mui/material/AccordionSummary"
 import Alert from "@mui/material/Alert"
 import Box from "@mui/material/Box"
 import Button from "@mui/material/Button"
 import Paper from "@mui/material/Paper"
 import Slider from "@mui/material/Slider"
+import ToggleButton from "@mui/material/ToggleButton"
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup"
 import Typography from "@mui/material/Typography"
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import SearchRoundedIcon from "@mui/icons-material/SearchRounded"
 import WarningAmberRoundedIcon from "@mui/icons-material/WarningAmberRounded"
 import type { ScanSettings } from "../lib/types"
@@ -50,39 +56,78 @@ export function ScanConfig({
           AI-powered image comparison.
         </Typography>
 
-        <Box sx={{ mb: 4 }}>
-          <Typography variant="body2" fontWeight={500} sx={{ mb: 2 }}>
-            Similarity Threshold:{" "}
-            <strong>{settings.similarityThreshold}</strong>
-          </Typography>
-          <Slider
-            min={0.9}
-            max={1.0}
-            step={0.01}
-            value={settings.similarityThreshold}
-            valueLabelDisplay="auto"
-            onChange={(_, value) =>
-              onSettingsChange({ similarityThreshold: value as number })
-            }
-          />
-          <Box sx={{ display: "flex", justifyContent: "space-between", mt: 0.5 }}>
-            <Typography variant="caption" color="text.secondary">
-              More matches
-            </Typography>
-            <Typography variant="caption" color="text.secondary">
-              Exact only
-            </Typography>
-          </Box>
-        </Box>
-
         <Button
           variant="contained"
           fullWidth
           size="large"
           startIcon={<SearchRoundedIcon />}
-          onClick={onStartScan}>
+          onClick={onStartScan}
+          sx={{ mb: 2 }}>
           Scan Library
         </Button>
+
+        <Accordion
+          disableGutters
+          elevation={0}
+          sx={{
+            border: "1px solid",
+            borderColor: "divider",
+            borderRadius: 1,
+            "&:before": { display: "none" },
+          }}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography variant="body2" color="text.secondary">
+              More options
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Box sx={{ mb: 3 }}>
+              <Typography variant="body2" fontWeight={500} sx={{ mb: 1 }}>
+                Scan mode
+              </Typography>
+              <ToggleButtonGroup
+                value={settings.scanMode}
+                exclusive
+                size="small"
+                onChange={(_, value) => {
+                  if (value !== null) onSettingsChange({ scanMode: value })
+                }}>
+                <ToggleButton value="smart">Smart</ToggleButton>
+                <ToggleButton value="full">Full</ToggleButton>
+              </ToggleButtonGroup>
+              <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5 }}>
+                {settings.scanMode === "smart"
+                  ? "Only compares photos taken at the same time — fast for large libraries."
+                  : "Compares all photos against each other — thorough but slow for large libraries."}
+              </Typography>
+            </Box>
+
+            <Box>
+              <Typography variant="body2" fontWeight={500} sx={{ mb: 1 }}>
+                Similarity Threshold:{" "}
+                <strong>{settings.similarityThreshold}</strong>
+              </Typography>
+              <Slider
+                min={0.9}
+                max={1.0}
+                step={0.01}
+                value={settings.similarityThreshold}
+                valueLabelDisplay="auto"
+                onChange={(_, value) =>
+                  onSettingsChange({ similarityThreshold: value as number })
+                }
+              />
+              <Box sx={{ display: "flex", justifyContent: "space-between", mt: 0.5 }}>
+                <Typography variant="caption" color="text.secondary">
+                  More matches
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Exact only
+                </Typography>
+              </Box>
+            </Box>
+          </AccordionDetails>
+        </Accordion>
       </Paper>
     </Box>
   )

--- a/docs/dedup-filtering-spec.md
+++ b/docs/dedup-filtering-spec.md
@@ -1,0 +1,143 @@
+# Deduplication Filtering & Results — Feature Spec
+
+> **Context:** The tool compares photos via perceptual image embeddings (MediaPipe MobileNet V3, cosine similarity). It is fast and quota-safe. Both taken date and upload date are available from the API. This spec evaluates user-requested features from [#7](https://github.com/mtalcott/google-photos-deduper/issues/7), [#19](https://github.com/mtalcott/google-photos-deduper/issues/19), and [discussion #41](https://github.com/mtalcott/google-photos-deduper/discussions/41) in this context and identifies new improvements.
+
+---
+
+## What the Old Issues Asked For — and Where Things Stand
+
+| Request | Origin | Status |
+|---|---|---|
+| API quota / 429 throttling | #41 | **Resolved** — no per-photo API calls during scanning |
+| False positives from filename/filesize matching | #41 | **Resolved** — visual embeddings are the only signal |
+| Similarity threshold control | #41, #7 | **Already implemented** — slider (0.90–1.00, default 0.99) |
+| Filter results by similarity, filename, resolution | #7, #41 | **Not implemented** |
+| Date range scan filter | #19 | **Partially implemented** — types + code path exist, no UI |
+| Sort results by similarity or group size | #7 (owner comment) | **Not implemented** |
+| Smarter "keep" selection | implicit | **Not implemented** — currently defaults to oldest upload |
+
+---
+
+## Feature Proposals
+
+Ordered by priority.
+
+---
+
+### 1. Smarter Default "Keep" Selection
+
+**Priority: High**
+
+Currently, the first-uploaded photo in a group is pre-selected as the one to keep. This is a poor heuristic — a low-quality Storage Saver copy uploaded years ago will be kept over a higher-resolution original uploaded later.
+
+**Requirements:**
+
+The default "keep" selection within each duplicate group should follow this priority order, applied in sequence:
+
+1. **Original quality over Storage Saver** — if any item in the group is original quality and others are Storage Saver, always pre-select the original-quality item(s).
+2. **Higher resolution** — among items of equal quality tier, pre-select the one with the greatest pixel count (width × height).
+3. **Oldest upload date** — as a tiebreaker when quality and resolution are identical, prefer the earliest-uploaded item (current behavior).
+
+When multiple items tie across all three criteria, keep the current behavior (first in sorted order).
+
+**Behavior:**
+- This auto-selection is a default starting point only. Users retain full ability to override by clicking any photo in the group.
+- The constraint that at least one photo per group must be marked Keep is unchanged.
+- The selection logic runs after scan completes; no re-scan is required when viewing existing results.
+
+---
+
+### 2. Sort Results
+
+**Priority: High**
+
+Users with large libraries can generate hundreds or thousands of duplicate groups. The current fixed ordering (largest group first) gives no control over where to start.
+
+**Requirements:**
+
+- **Sort by group size** (number of photos) — largest first (current default), or smallest first.
+- **Sort by similarity** — highest average similarity first, or lowest first. This lets users start with the most confident duplicates.
+- **Sort by date** — group's oldest photo taken date, ascending or descending. Useful for working through a library chronologically.
+- Sort controls are in the results view and apply instantly without re-scanning.
+- The selected sort order should persist in settings.
+
+---
+
+### 3. Date Range Scan Filter (UI)
+
+**Priority: High**
+
+The code infrastructure for date range filtering already exists (`ScanSettings.dateRange`, passed to `getAllMediaItems`). It just needs a UI.
+
+**Requirements:**
+
+- Two optional date fields in the scan configuration: **From** and **To**.
+- Both fields accept a calendar date. Either can be left blank to mean "no bound."
+- Filtering applies to **both taken date and upload date**: a photo is included if either its taken date or its upload date falls within the range. *(See note below.)*
+- Alternatively, expose separate "filter by taken date" vs. "filter by upload date" options if the API supports distinct filtering; otherwise apply to whichever date field GPTK passes through.
+- The date range persists in settings between sessions.
+- A clear "scanning X of Y photos in library" indicator should reflect the filtered count.
+
+**Use case:** A user who knows duplicates were imported during a specific period (e.g., a bulk import in 2019) can scan only that window rather than the full 100K-photo library.
+
+---
+
+### 4. Filter Results by Similarity Score
+
+**Priority: Medium**
+
+After scanning, users want to work in passes — first clearing obvious duplicates (very high similarity), then reviewing borderline ones.
+
+**Requirements:**
+
+- A minimum similarity filter in the results view (e.g., a slider or numeric input).
+- Groups whose average similarity falls below the filter threshold are hidden from the list.
+- The filter operates on already-computed results; no re-scan is needed.
+- Lowering the filter below the original scan threshold has no effect (can't recover groups that were never detected).
+- The current scan threshold should be shown as context (e.g., "Scan threshold: 99% — showing groups above 95%").
+
+---
+
+### 5. Re-Evaluate Threshold Without Re-Scanning
+
+**Priority: Medium**
+
+Currently, changing the similarity threshold requires a full re-scan. But embeddings are already computed — regrouping them with a different threshold is fast.
+
+**Requirements:**
+
+- After a scan completes, the user can raise or lower the similarity threshold and click a "Re-group" or "Apply" action.
+- Re-grouping reuses the cached embeddings; it does not re-fetch media items or re-compute embeddings.
+- Lowering the threshold may produce more (or larger) groups. Raising it will produce fewer.
+- This is distinct from the full "Re-scan" action, which re-fetches media and recomputes everything.
+
+**Constraint:** This requires cached embeddings to be stored (not just the final groups). Verify storage budget before implementing — embedding vectors for large libraries may be sizable.
+
+---
+
+### 6. Filename Match as a Results Filter
+
+**Priority: Low**
+
+When a user suspects duplicates are re-uploads of the same file, they may want to see only groups where the filenames also match — as extra confirmation before trashing.
+
+**Requirements:**
+
+- A toggle in the results view: "Only show groups with matching filenames."
+- When enabled, groups are hidden if the filenames differ across the items in that group.
+- This is a post-scan filter on existing results, not a scan strategy. It does not find additional duplicates; it narrows existing ones.
+- Filename data requires the extended media info fetch (already part of the scan pipeline).
+
+**Why not a scan strategy:** Filename-only matching was a source of false positives in the old tool (different photos coincidentally sharing a filename). Visual similarity is the correct primary signal; filename is only useful as a confirmation filter.
+
+---
+
+## Out of Scope
+
+| Request | Disposition |
+|---|---|
+| Matching by file size | File size is not displayed and not reliably available (Storage Saver items have unreliable sizes). Visual similarity supersedes it as a signal. |
+| Matching by filename alone (scan strategy) | Causes false positives. Addressed as a post-scan filter (feature 6). |
+| Hard cap on number of results ("show first N") | Sort + similarity filter (features 2 & 4) give users principled control without a blunt cap. |
+| Camera/EXIF metadata in results | Not available from the API in the current data pipeline. |
+| File size display per photo | Not reliably available; Storage Saver copies may show 0 or nothing. Low value given resolution is already shown. |

--- a/docs/embedding-cache.md
+++ b/docs/embedding-cache.md
@@ -1,0 +1,58 @@
+# Embedding Cache
+
+## Background
+
+A full scan of a ~50k-item Google Photos library was instrumented to measure where time is spent. The results drove a decision to cache embeddings in IndexedDB.
+
+## Measured Performance (50,534-item library)
+
+| Step | Time | Notes |
+|------|------|-------|
+| Fetch media items (API) | ~3 min | Unchanged |
+| Download thumbnails (h=200, cold) | **12.3 min** | 739s, concurrency=20 |
+| Download thumbnails (HTTP-cached) | **~4 min** | Browser cache helps on re-scans |
+| Model download (10.4MB) | **0.2s** | CDN-cached, low priority |
+| Compute embeddings (MediaPipe) | **~60 min** | Serial, ~10 items/sec |
+| Community detection | <1s | In-memory matrix ops |
+
+**Total cold scan: ~75 min. Dominated by serial embedding computation.**
+
+### Storage sizes
+
+| What | Size |
+|------|------|
+| Thumbnails (h=200, 48k photos) | ~819MB total, 17.2KB avg |
+| Embeddings (1280-dim float32) | **5.0KB/item → ~238MB for 48k items** |
+| MediaPipe model | 10.4MB |
+
+## Why Cache Embeddings (Not Thumbnails or the Model)
+
+**Thumbnails (~819MB):** Too large to store in IndexedDB. Google's CDN already caches them at the HTTP layer, so repeat downloads are ~4 min instead of 12 min anyway. Not worth it.
+
+**Model (10.4MB):** Already downloads in ~0.2s from CDN. Low priority — the scan would need to be run offline for this to matter.
+
+**Embeddings (~238MB):** This is the bottleneck. Serial MediaPipe inference at ~10 items/sec means ~60 min per scan for a 48k-photo library. Embeddings are deterministic — the same image always produces the same 1280-dim float32 vector. Caching them in IndexedDB eliminates both the thumbnail download step and the embedding computation step on all subsequent scans.
+
+## Implementation
+
+Two files changed:
+
+**`lib/embedding-cache.ts`** — IndexedDB wrapper around a single object store (`embeddings`, keyPath: `mediaKey`). Methods: `open()`, `getMany()`, `setMany()`, `evictExcept()`.
+
+**`lib/duplicate-detector.ts`** — `detectDuplicates` now:
+1. Opens the cache and batch-fetches embeddings for all candidates
+2. Skips thumbnail download for items with cache hits
+3. Only runs MediaPipe inference on cache misses
+4. Persists newly computed embeddings back to cache
+5. Evicts stale entries (deleted photos) at end of scan
+
+Cache key: `mediaKey` (stable — Google Photos doesn't edit originals in-place).
+
+## Expected Scan Times After First Run
+
+| Scenario | Time |
+|----------|------|
+| First scan (cold cache) | ~75 min (unchanged) |
+| Re-scan, same library | ~1 min (media fetch only) |
+| Re-scan, N new photos | ~1 min + N × 0.1s |
+| Extension reinstall / cache cleared | ~75 min (full recompute) |

--- a/docs/pr-104-comment.md
+++ b/docs/pr-104-comment.md
@@ -1,0 +1,31 @@
+Thanks for the contributions! The bulk IndexedDB reads and web worker offloading are great improvements.
+
+Two algorithmic issues needed fixing before merge, plus one small build thing:
+
+---
+
+**1. Community detection: O(n) walk misses non-consecutive duplicates**
+
+The new algorithm sorts by timestamp then only compares adjacent pairs. This means two duplicate photos with any non-duplicate taken between them are never compared and the group is missed:
+
+- Photo A (t=1, burst shot) — duplicate of C
+- Photo B (t=2, different scene)
+- Photo C (t=3, burst shot) — **never compared to A**
+
+Burst shots can interleave with photos from other cameras, and re-uploads may land at very different timestamps. The original O(n²) approach (check every pair) is slower but correct — reverted to that.
+
+---
+
+**2. Duplicate community detection implementations**
+
+The PR kept `communityDetection` in `lib/duplicate-detector.ts` for tests while running a separately-maintained copy inside the worker. The two had already drifted (`topK` used a simple `Array.sort` in the worker vs. a min-heap in lib). Fixed by extracting into a new shared `lib/community-detection.ts` module imported by both the worker and tests.
+
+---
+
+**3. Worker build missing from dev script** (minor)
+
+Added the worker build step to `dev`, not just the prod build.
+
+---
+
+Rebased off main and pushed fixes directly to this branch — now merged!

--- a/docs/test-coverage-plan.md
+++ b/docs/test-coverage-plan.md
@@ -1,0 +1,339 @@
+# QA Audit & Test Coverage Improvement Plan
+
+## Context
+
+The extension has decent unit test coverage of isolated components but is missing an integration test that exercises the full cross-tab messaging pipeline with a stubbed Google Photos backend. The user specifically requested an integration test that loads the real GPTK but stubs Google Photos network traffic.
+
+## Current Coverage Snapshot
+
+| Layer | File(s) | What's Covered |
+|---|---|---|
+| Unit (Vitest) | `app-reducer`, `duplicate-detector`, `multi-keep` | State machine, dedup logic, keep logic |
+| Unit (Vitest) | `duplicate-groups`, `photo-viewer-modal` | React component rendering |
+| Unit (Vitest) | `service-worker.test.ts` | Message routing with fully mocked Chrome APIs |
+| Integration (Playwright) | `app-tab.test.ts` | 3 UI states via pre-injected storage — no real messaging |
+| Full E2E (Playwright) | `scan-flow`, `trash-flow` | Real Google Photos, requires auth |
+
+**Zero coverage:** `contents/google-photos-bridge.ts`, `scripts/google-photos-commands.js`, cross-tab message chain end-to-end, progress updates in UI, tab-close error propagation.
+
+**Zero coverage (added with embedding cache):** `lib/embedding-cache.ts` (all methods), `detectDuplicates` main function (cache-hit path, partial-hit path, IDB-error fallback).
+
+---
+
+## Priority-Ordered Gap List
+
+| # | Gap | Leverage |
+|---|---|---|
+| 1 | **Cross-tab messaging integration test** (requested) | Highest — no test verifies GPTK → bridge → SW → app tab round-trip |
+| 2 | **mock-google-photos.ts fixture** | Blocker for #1 — batchexecute response format is complex |
+| 3 | **Tab close mid-operation propagates error** | High safety — common user scenario; `chrome.tabs.onRemoved` path untested end-to-end |
+| 4 | **trashItems: verify dedupKeys reach batchexecute** | High correctness — wrong keys = wrong user photos trashed |
+| 5 | **Bridge content script unit tests** | Medium — 40-line file, all logic untested; fast Vitest tests |
+| 6 | **getAllMediaItems progress updates visible in UI** | Medium — progress chain untested; harder due to MediaPipe thumbnail dependency |
+| 7 | **google-photos-commands.js unit tests** | Lower — integration tests cover same paths |
+| 8 | **`EmbeddingCache` unit tests** | Medium — IndexedDB wrapper; all 4 methods (`getMany`, `setMany`, `evictExcept`, `open`) untested; use `fake-indexeddb` |
+| 9 | **`detectDuplicates` cache-hit/fallback paths** | Medium — cache-hit path skips thumbnail+embedding steps; IDB-error fallback resets to full scan; neither path is exercised by existing tests |
+
+---
+
+## Implementation Plan
+
+### Step 1 — `tests/e2e/fixtures/mock-google-photos.ts`
+
+New fixture providing Playwright route interception for Google Photos. Called on the `BrowserContext` from `launchExtension()` before navigating to photos.google.com.
+
+**Key technical facts confirmed from source:**
+- `windowGlobalData.ts` reads `eptZe` (not `ePtZe`) for the path field
+- URL constructed as: `https://photos.google.com${windowGlobalData.path}data/batchexecute`
+- So `eptZe` should be `"/_/PhotosUi/"` → URL becomes `/_/PhotosUi/data/batchexecute`
+- `makeApiRequest` response parsing: split on `\n`, find line with `wrb.fr`, `JSON.parse(line)[0][2]` is a JSON-encoded payload string
+
+**Fake HTML served at `https://photos.google.com/`:**
+```html
+<!DOCTYPE html><html>
+<head>
+  <title>Google Photos (mock)</title>
+  <script>
+    window.WIZ_global_data = {
+      SNlM0e: "fake-at-token",
+      FdrFJe: "-1234567890",
+      cfb2h: "fake-bl",
+      eptZe: "/_/PhotosUi/",
+      oPEP7c: "test@example.com"
+    };
+  </script>
+</head>
+<body><div id="app">Google Photos (mock)</div></body>
+</html>
+```
+
+**`buildBatchexecuteResponse(rpcid, payload)`** — produces the wire format:
+```
+)]}'\n[[["wrb.fr","<rpcid>","<JSON.stringify(payload)>",null,null,null,"generic"]]]\n
+```
+
+**`buildLibraryGenericPagePayload(items: FakeMediaItem[], nextPageId = null)`** — produces the payload for `EzkLib`. Confirmed structure from `parser.ts:libraryItemParse()`:
+```typescript
+// payload = [itemsArray, nextPageId]
+// Each item array (minimum safe structure):
+[
+  mediaKey,              // [0]
+  [thumb, width, height], // [1]
+  timestamp,             // [2]
+  dedupKey,              // [3]
+  null,                  // [4] timezoneOffset
+  creationTimestamp,     // [5]
+  null, [], null, null, null, null, null, null, null, null,
+  {}                     // at(-1) — optional metadata object
+]
+```
+
+**Route handler logic:**
+```typescript
+context.route('https://photos.google.com/**', async (route) => {
+  const url = route.request().url()
+  if (url === 'https://photos.google.com/' || url === 'https://photos.google.com') {
+    return route.fulfill({ contentType: 'text/html', body: FAKE_GP_HTML })
+  }
+  if (url.includes('batchexecute')) {
+    // capture call, determine rpcid from URL ?rpcids= param
+    // return configured response
+    return route.fulfill({ body: buildBatchexecuteResponse(...) })
+  }
+  // favicon, static assets, etc. — abort cleanly
+  return route.abort()
+})
+```
+
+**Public API of the fixture:**
+```typescript
+export async function setupMockGooglePhotos(
+  context: BrowserContext,
+  options?: {
+    mediaItems?: FakeMediaItem[]   // items returned from getAllMediaItems
+    trashShouldSucceed?: boolean   // default true
+    delayMs?: number               // artificial delay for batchexecute (for tab-close test)
+  }
+): Promise<{
+  getBatchexecuteCalls(): CapturedRequest[]  // for asserting dedupKeys
+  unroute(): Promise<void>                   // call in afterEach
+}>
+```
+
+**`FakeMediaItem` type:**
+```typescript
+interface FakeMediaItem {
+  mediaKey: string; dedupKey: string
+  thumb?: string       // use a stable interceptable URL: "https://photos.google.com/fake-thumb/1.jpg"
+  timestamp?: number; creationTimestamp?: number
+  resWidth?: number; resHeight?: number
+}
+```
+
+For thumbnail route interception: intercept `https://photos.google.com/fake-thumb/**` and return a hardcoded 1×1 JPEG (base64). This lets MediaPipe compute embeddings for all items. Using the **same** URL for all items means identical embeddings → similarity = 1.0 → they form duplicate groups.
+
+**Captured request type:**
+```typescript
+interface CapturedRequest {
+  rpcid: string         // from ?rpcids= URL param
+  postData: string      // raw body
+  decodedFReq: unknown  // JSON.parse(decodeURIComponent(urlParams.get("f.req")))
+}
+```
+
+To decode trash dedupKeys from a captured request:
+```typescript
+const fReq = JSON.parse(decodeURIComponent(new URLSearchParams(call.postData).get("f.req")))
+const requestData = JSON.parse(fReq[0][0][1])  // inner encoded string
+const dedupKeys = requestData[2]               // [null, 1, dedupKeyArray, 3]
+```
+
+---
+
+### Step 2 — `tests/e2e/integration/messaging-flow.test.ts`
+
+Uses `launchExtension()` + `setupMockGooglePhotos()`. Playwright config: `playwright.config.ts` (same as `app-tab.test.ts`). Requires `npm run dev` build.
+
+**Test setup pattern:**
+```typescript
+let context: BrowserContext, extensionId: string, gpPage: Page, mock: MockGP
+
+test.beforeAll(async () => {
+  ({ context, extensionId } = await launchExtension())
+})
+test.afterAll(async () => { await context.close() })
+test.beforeEach(async () => {
+  await clearStorage(context)
+  mock = await setupMockGooglePhotos(context, { mediaItems: buildFakeMediaItems(2) })
+  gpPage = await context.newPage()
+  await gpPage.goto('https://photos.google.com/')
+  // Wait for GPTK to fully load in MAIN world before opening app tab
+  await gpPage.waitForFunction(() => typeof window.gptkApi !== 'undefined', { timeout: 15_000 })
+})
+test.afterEach(async () => {
+  await gpPage.close()
+  await mock.unroute()
+})
+```
+
+**Test 1: `healthCheck flows end-to-end`**
+```
+1. Open app tab (after gpPage is ready per beforeEach)
+2. Assert "Scan Library" button visible (timeout: 10s) — proves status === "connected"
+3. Assert "test@example.com" visible in UI — proves accountEmail propagated correctly
+```
+Full chain exercised: app tab → SW → bridge → MAIN world healthCheck → postResult → bridge → SW → app tab.
+
+**Test 2: `tab close mid-operation returns error to app tab`**
+
+Override mock in this test to use a slow batchexecute handler (6s delay via `delayMs` option):
+```typescript
+mock = await setupMockGooglePhotos(context, { mediaItems: [...], delayMs: 6000 })
+```
+Steps:
+```
+1. Open app tab, wait for connected state
+2. Click "Scan Library"
+3. Wait for scanning indicator ("Fetching" text)
+4. Close gpPage: await gpPage.close()
+5. Assert app tab shows disconnected/error state within 5s
+```
+Service worker `chrome.tabs.onRemoved` → sends `gptkLog` error → app tab dispatches `GP_TAB_CLOSED`.
+
+**Test 3: `trashItems sends correct dedupKeys to batchexecute`**
+```
+1. Build 2 fake items with same thumb URL (same dedupKey values known in test)
+2. Open app tab, scan library
+3. Wait for "1 Duplicate Group Found" (same thumb → same embedding → similarity 1.0)
+4. Click "Move N Duplicates to Trash", confirm dialog
+5. Wait for undo snackbar (trash success)
+6. const calls = mock.getBatchexecuteCalls().filter(c => c.rpcid === 'XwAOJf')
+7. Decode dedupKeys from calls[0]
+8. Assert exactly 1 dedupKey present (the non-kept duplicate)
+```
+
+**Test 4: `getAllMediaItems sends progress and completes scan`** (optional, more complex)
+```
+1. Build 4 fake items (2 pairs with shared thumb URLs)
+2. Open app tab, click Scan Library
+3. Assert progress text like /Fetched \d+ items/ appears during scanning
+4. Wait for results showing 2 duplicate groups (timeout: 60s for MediaPipe)
+```
+Note: MediaPipe loads WASM from the extension build; thumbnail fetch succeeds via fake-thumb route. May be slow.
+
+---
+
+### Step 3 — `tests/contents/google-photos-bridge.test.ts`
+
+Vitest unit test. Uses same pattern as `service-worker.test.ts`: set up chrome mock globally, capture listener arrays, import module in `beforeAll`.
+
+**Mock setup:**
+```typescript
+const runtimeListeners: ((msg, sender, sendResponse) => void)[] = []
+const sentMessages: unknown[] = []
+
+vi.stubGlobal('chrome', {
+  runtime: {
+    onMessage: { addListener: vi.fn(fn => runtimeListeners.push(fn)) },
+    sendMessage: vi.fn(msg => sentMessages.push(msg))
+  }
+})
+
+beforeAll(async () => { await import('../../contents/google-photos-bridge') })
+beforeEach(() => { vi.clearAllMocks(); sentMessages.length = 0 })
+```
+
+**Note on `import type`:** The bridge has `import type { PlasmoCSConfig } from "plasmo"` — type-only, erased at runtime. No mock needed for Plasmo. `import { APP_ID } from "../lib/types"` resolves fine.
+
+**Test cases (8):**
+1. Forwards `gptkResult` from `window.postMessage` to `chrome.runtime.sendMessage`
+2. Forwards `gptkProgress` from window to runtime
+3. Forwards `gptkLog` from window to runtime
+4. Does NOT forward `gptkCommand` from window to runtime (command goes the other direction)
+5. Ignores window messages where `event.source !== window`
+6. Ignores window messages with wrong `app` field
+7. Forwards `gptkCommand` from chrome.runtime to `window.postMessage` (use `vi.spyOn(window, 'postMessage')`)
+8. Does NOT forward non-`gptkCommand` messages from runtime to window
+
+---
+
+### Step 4 — `tests/lib/embedding-cache.test.ts`
+
+Vitest unit test. Use the `fake-indexeddb` package to provide an in-memory IndexedDB implementation (install: `npm install -D fake-indexeddb`).
+
+**Setup:**
+```typescript
+import "fake-indexeddb/auto"  // replaces globalThis.indexedDB with in-memory impl
+import { EmbeddingCache } from "../../lib/embedding-cache"
+
+beforeEach(() => {
+  // fake-indexeddb resets between tests only if you re-open; use unique DB names
+  // or reset via IDBFactory.deleteDatabase between tests
+})
+```
+
+**Test cases (10):**
+1. `open()` — resolves to an EmbeddingCache instance without throwing
+2. `open()` twice — both resolve (idempotent)
+3. `getMany([])` — returns empty array
+4. `getMany` for unknown keys — returns array of nulls (all misses)
+5. `setMany` then `getMany` — round-trips embeddings correctly (Float32Array values preserved)
+6. `getMany` with mixed hits/misses — returns correct embedding at hit indices, null at miss indices
+7. `setMany` overwrites existing entry — get returns updated value
+8. `setMany([])` — resolves without error (no-op)
+9. `evictExcept` — deletes keys not in the keep set, returns evicted count
+10. `evictExcept` with all keys in keep set — returns 0, no entries deleted
+
+**Note on `detectDuplicates` cache paths:** The cache-hit and IDB-error-fallback branches in `detectDuplicates` are difficult to unit test because the function also invokes MediaPipe and `fetch`. These paths are best covered by the integration test (Test 3/4 in messaging-flow.test.ts — cache is implicitly cold on first scan). A second-scan integration test could verify the hit path but is low priority given MediaPipe's 60s runtime.
+
+---
+
+## Files to Create
+
+| File | Type | Runner |
+|---|---|---|
+| `tests/e2e/fixtures/mock-google-photos.ts` | New fixture | Playwright |
+| `tests/e2e/integration/messaging-flow.test.ts` | New tests | Playwright (`npm run test:integration`) |
+| `tests/contents/google-photos-bridge.test.ts` | New tests | Vitest (`npm test`) |
+| `tests/lib/embedding-cache.test.ts` | New tests | Vitest (`npm test`) |
+
+## Files to Modify
+
+None — all additions.
+
+---
+
+## Verification
+
+**Unit tests (bridge):**
+```bash
+npm test -- tests/contents/google-photos-bridge.test.ts
+```
+Expect 8 tests passing in ~2s.
+
+**Unit tests (embedding cache):**
+```bash
+npm test -- tests/lib/embedding-cache.test.ts
+```
+Expect 10 tests passing in ~2s. Requires `fake-indexeddb` dev dependency.
+
+**Integration tests (messaging flow):**
+```bash
+npm run dev   # keep running in background (watches for changes)
+npm run test:integration
+```
+Tests 1–3 should complete in ~30s. Test 4 (if included) may need ~60s for MediaPipe.
+
+**Confirm full suite still passes:**
+```bash
+npm test && npm run test:integration
+```
+
+---
+
+## Key Assumptions to Verify at Impl Time
+
+1. **`eptZe` path value**: Use `"/_/PhotosUi/"` so the constructed batchexecute URL is `https://photos.google.com/_/PhotosUi/data/batchexecute`. Verify this URL is what Playwright route intercepts.
+2. **Thumbnail MediaPipe flow**: Confirm `https://photos.google.com/fake-thumb/1.jpg` route returns a valid JPEG that MediaPipe can process (1×1 JPEG base64 should work).
+3. **Service worker tab query**: Confirm `chrome.tabs.query({ url: "https://photos.google.com/*" })` matches a tab where navigation was fulfilled by Playwright route interception.
+4. **GPTK inject timing**: `waitForFunction(() => typeof window.gptkApi !== 'undefined')` in the GP page is the correct sync point before opening the app tab.

--- a/lib/app-reducer.ts
+++ b/lib/app-reducer.ts
@@ -118,6 +118,11 @@ export function appReducer(state: AppState, action: AppAction): AppState {
 
     case "SCAN_PROGRESS":
       if (state.status !== "scanning") return state
+      // action.phase === undefined means this came from a GPTK gptkProgress message.
+      // GPTK sends batched fetch counts asynchronously and can arrive after gptkResult
+      // has already triggered the downloading/computing phases. Drop those stale counts
+      // to prevent the bar from jumping backwards.
+      if (action.phase === undefined && state.phase !== "fetching") return state
       return {
         ...state,
         ...(action.phase !== undefined ? { phase: action.phase } : {}),

--- a/lib/duplicate-detector.ts
+++ b/lib/duplicate-detector.ts
@@ -441,7 +441,9 @@ export async function smartDetectDuplicates(
   windowMs = 1000,
   onProgress?: ProgressCallback,
   signal?: AbortSignal,
+  logger?: ScanLogger,
 ): Promise<DuplicateGroup[]> {
+  const scanStart = performance.now();
   const candidates = mediaItems.filter((item) => item.thumb && !item.duration);
 
   // Step 1: Bucket by timestamp — no I/O, instant
@@ -474,18 +476,47 @@ export async function smartDetectDuplicates(
   const cachedKeySet: Set<string> = db
     ? await loadCachedEmbeddingKeys(db)
     : new Set();
+  const cacheHits = keys.filter((k) => cachedKeySet.has(k)).length;
+  console.log(
+    `[GPD] embedding cache: ${cacheHits}/${subset.length} hits, skipping thumbnails`,
+  );
 
-  const blobs = await fetchThumbnails(subset, cachedKeySet, onProgress, signal);
+  logger?.updateInfo({ candidates: subset.length, cacheHits });
+
+  // Wrap onProgress to feed stability tracking alongside the UI callback.
+  const stabilityTracker = new StabilityTracker((est) =>
+    logger?.recordStableEstimate(est),
+  );
+  const trackedProgress: ProgressCallback = (progress) => {
+    onProgress?.(progress);
+    stabilityTracker.update(progress.phase, progress.current, progress.total);
+  };
+
+  const t1 = performance.now();
+  const blobs = await fetchThumbnails(subset, cachedKeySet, trackedProgress, signal);
+  const fetchThumbnailsMs = Math.round(performance.now() - t1);
+  console.log(
+    `[GPD] fetchThumbnails: ${subset.length - cacheHits} items in ${fetchThumbnailsMs}ms`,
+  );
+  await logger?.phaseComplete("fetchThumbnailsMs", fetchThumbnailsMs);
+
   signal?.throwIfAborted();
 
+  const t2 = performance.now();
   const { embeddings, validIndices } = await computeEmbeddings(
     blobs,
     keys,
     db,
     cachedKeySet,
-    onProgress,
+    trackedProgress,
     signal,
   );
+  const computeEmbeddingsMs = Math.round(performance.now() - t2);
+  console.log(
+    `[GPD] computeEmbeddings: ${embeddings.length} items (${cacheHits} cached) in ${computeEmbeddingsMs}ms`,
+  );
+  await logger?.phaseComplete("computeEmbeddingsMs", computeEmbeddingsMs);
+
   if (embeddings.length < 2) return [];
 
   // Build bucket index arrays (indices into embeddings[])
@@ -504,17 +535,25 @@ export async function smartDetectDuplicates(
   if (workerBuckets.length === 0) return [];
 
   // Offload pairwise comparison to worker
-  onProgress?.({ phase: "detecting_duplicates", current: 0, total: 0 });
+  trackedProgress({ phase: "detecting_duplicates", current: 0, total: 0 });
   await new Promise<void>((r) => setTimeout(r, 0)); // flush React phase update
   const workerUrl = chrome.runtime.getURL("scripts/embedder-worker.js");
+  const t3 = performance.now();
   const indexGroups = await runSmartDetectionInWorker(
     embeddings,
     threshold,
     workerBuckets,
     workerUrl,
-    onProgress,
+    trackedProgress,
     signal,
   );
+  const communityDetectionMs = Math.round(performance.now() - t3);
+  const totalMs = Math.round(performance.now() - scanStart);
+  console.log(
+    `[GPD] communityDetection: ${indexGroups.length} groups in ${communityDetectionMs}ms`,
+  );
+  console.log(`[GPD] scan complete: ${totalMs}ms total`);
+  await logger?.phaseComplete("communityDetectionMs", communityDetectionMs);
 
   // Map indices back to GpdMediaItems
   const groups: DuplicateGroup[] = indexGroups.map((indices, i) => {

--- a/lib/duplicate-detector.ts
+++ b/lib/duplicate-detector.ts
@@ -438,7 +438,7 @@ async function runSmartDetectionInWorker(
 export async function smartDetectDuplicates(
   mediaItems: GpdMediaItem[],
   threshold: number,
-  windowMs = 0,
+  windowMs = 1000,
   onProgress?: ProgressCallback,
   signal?: AbortSignal,
 ): Promise<DuplicateGroup[]> {

--- a/lib/duplicate-detector.ts
+++ b/lib/duplicate-detector.ts
@@ -129,10 +129,10 @@ export interface ScanTiming {
 type ProgressCallback = (progress: DetectionProgress) => void;
 
 // ============================================================
-// Main entry point
+// Main entry points
 // ============================================================
 
-export async function detectDuplicates(
+export async function fullDetectDuplicates(
   mediaItems: GpdMediaItem[],
   threshold: number,
   onProgress?: ProgressCallback,
@@ -286,6 +286,250 @@ export async function detectDuplicates(
   };
 
   return { groups, timing };
+}
+
+// ============================================================
+// Smart scan: group by timestamp, embed subset, pairwise union-find
+// ============================================================
+
+/**
+ * Group media items by their `timestamp` field (EXIF taken date).
+ * Only returns buckets with ≥ 2 items.
+ *
+ * windowMs = 0 (default): exact timestamp match.
+ * windowMs > 0: items within the same time window are bucketed together.
+ *
+ * Exported for unit testing.
+ */
+export function groupByTimestamp(
+  items: GpdMediaItem[],
+  windowMs = 0,
+): GpdMediaItem[][] {
+  const buckets = new Map<number, GpdMediaItem[]>();
+  for (const item of items) {
+    const key =
+      windowMs > 0
+        ? Math.floor(item.timestamp / windowMs) * windowMs
+        : item.timestamp;
+    if (!buckets.has(key)) buckets.set(key, []);
+    buckets.get(key)!.push(item);
+  }
+  return [...buckets.values()].filter((g) => g.length >= 2);
+}
+
+/**
+ * Given a single timestamp-bucket group, compute duplicate groups using
+ * pairwise cosine similarity + union-find.
+ *
+ * Exported for unit testing. The worker contains an equivalent inline copy.
+ */
+export function withinGroupDuplicates(
+  groupItems: GpdMediaItem[],
+  embeddingMap: Map<string, Float32Array>,
+  threshold: number,
+  groupIdOffset: number,
+): DuplicateGroup[] {
+  const withEmb = groupItems
+    .map((item) => ({ item, emb: embeddingMap.get(item.mediaKey) }))
+    .filter(
+      (x): x is { item: GpdMediaItem; emb: Float32Array } => !!x.emb,
+    );
+  if (withEmb.length < 2) return [];
+
+  // Union-Find
+  const parent = withEmb.map((_, i) => i);
+  const find = (x: number): number =>
+    parent[x] === x ? x : (parent[x] = find(parent[x]));
+  const union = (a: number, b: number) => {
+    parent[find(a)] = find(b);
+  };
+
+  const dim = withEmb[0].emb.length;
+  for (let i = 0; i < withEmb.length; i++) {
+    for (let j = i + 1; j < withEmb.length; j++) {
+      let dot = 0;
+      for (let k = 0; k < dim; k++) dot += withEmb[i].emb[k] * withEmb[j].emb[k];
+      if (dot >= threshold) union(i, j);
+    }
+  }
+
+  const components = new Map<number, GpdMediaItem[]>();
+  for (let i = 0; i < withEmb.length; i++) {
+    const root = find(i);
+    if (!components.has(root)) components.set(root, []);
+    components.get(root)!.push(withEmb[i].item);
+  }
+
+  return [...components.values()]
+    .filter((g) => g.length >= 2)
+    .map((items, i) => {
+      const sorted = [...items].sort(
+        (a, b) => (a.creationTimestamp ?? 0) - (b.creationTimestamp ?? 0),
+      );
+      return {
+        id: `group-${groupIdOffset + i}`,
+        mediaKeys: sorted.map((x) => x.mediaKey),
+        originalMediaKey: sorted[0].mediaKey,
+        similarity: threshold,
+      };
+    });
+}
+
+/**
+ * Packs embeddings and bucket index arrays, sends to worker for pairwise
+ * union-find detection. Returns number[][] (group index lists into embeddings[]).
+ */
+async function runSmartDetectionInWorker(
+  embeddings: Float32Array[],
+  threshold: number,
+  buckets: number[][],
+  workerUrl: string,
+  onProgress?: ProgressCallback,
+  signal?: AbortSignal,
+): Promise<number[][]> {
+  const n = embeddings.length;
+  if (n === 0) return [];
+  const dim = embeddings[0].length;
+
+  const flat = new Float32Array(n * dim);
+  for (let i = 0; i < n; i++) flat.set(embeddings[i], i * dim);
+
+  const worker = new Worker(workerUrl);
+
+  return new Promise<number[][]>((resolve, reject) => {
+    if (signal?.aborted) {
+      worker.terminate();
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+
+    const onAbort = () => {
+      worker.terminate();
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+
+    worker.onmessage = (e) => {
+      if (e.data.type === "detectionProgress") {
+        onProgress?.({
+          phase: "detecting_duplicates",
+          current: e.data.current,
+          total: e.data.total,
+        });
+      } else if (e.data.type === "detectionResults") {
+        signal?.removeEventListener("abort", onAbort);
+        worker.terminate();
+        resolve(e.data.groups as number[][]);
+      }
+    };
+    worker.onerror = (e) => {
+      signal?.removeEventListener("abort", onAbort);
+      worker.terminate();
+      reject(new Error(e.message ?? "Worker error during smart detection"));
+    };
+
+    worker.postMessage(
+      { type: "detectSmart", data: { flatEmbeddings: flat, n, dim, threshold, buckets } },
+      [flat.buffer],
+    );
+  });
+}
+
+export async function smartDetectDuplicates(
+  mediaItems: GpdMediaItem[],
+  threshold: number,
+  windowMs = 0,
+  onProgress?: ProgressCallback,
+  signal?: AbortSignal,
+): Promise<DuplicateGroup[]> {
+  const candidates = mediaItems.filter((item) => item.thumb && !item.duration);
+
+  // Step 1: Bucket by timestamp — no I/O, instant
+  const buckets = groupByTimestamp(candidates, windowMs);
+  console.log(
+    `[GPD] smartDetectDuplicates: ${mediaItems.length} items → ${candidates.length} candidates → ${buckets.length} timestamp buckets`,
+  );
+  if (buckets.length === 0) return [];
+
+  // Flatten to deduplicated subset
+  const seen = new Set<string>();
+  const subset: GpdMediaItem[] = [];
+  for (const bucket of buckets)
+    for (const item of bucket)
+      if (!seen.has(item.mediaKey)) {
+        seen.add(item.mediaKey);
+        subset.push(item);
+      }
+
+  const keys = subset.map((item) => item.mediaKey);
+
+  // Open embedding cache
+  let db: IDBDatabase | null = null;
+  try {
+    db = await openEmbeddingDb();
+  } catch {
+    /* cache unavailable */
+  }
+
+  const cachedKeySet: Set<string> = db
+    ? await loadCachedEmbeddingKeys(db)
+    : new Set();
+
+  const blobs = await fetchThumbnails(subset, cachedKeySet, onProgress, signal);
+  signal?.throwIfAborted();
+
+  const { embeddings, validIndices } = await computeEmbeddings(
+    blobs,
+    keys,
+    db,
+    cachedKeySet,
+    onProgress,
+    signal,
+  );
+  if (embeddings.length < 2) return [];
+
+  // Build bucket index arrays (indices into embeddings[])
+  const mediaKeyToEmbIdx = new Map<string, number>();
+  for (let i = 0; i < validIndices.length; i++)
+    mediaKeyToEmbIdx.set(subset[validIndices[i]].mediaKey, i);
+
+  const workerBuckets = buckets
+    .map((bucket) =>
+      bucket
+        .map((item) => mediaKeyToEmbIdx.get(item.mediaKey))
+        .filter((i): i is number => i !== undefined),
+    )
+    .filter((b) => b.length >= 2);
+
+  if (workerBuckets.length === 0) return [];
+
+  // Offload pairwise comparison to worker
+  onProgress?.({ phase: "detecting_duplicates", current: 0, total: 0 });
+  await new Promise<void>((r) => setTimeout(r, 0)); // flush React phase update
+  const workerUrl = chrome.runtime.getURL("scripts/embedder-worker.js");
+  const indexGroups = await runSmartDetectionInWorker(
+    embeddings,
+    threshold,
+    workerBuckets,
+    workerUrl,
+    onProgress,
+    signal,
+  );
+
+  // Map indices back to GpdMediaItems
+  const groups: DuplicateGroup[] = indexGroups.map((indices, i) => {
+    const items = indices
+      .map((idx) => subset[validIndices[idx]])
+      .sort((a, b) => (a.creationTimestamp ?? 0) - (b.creationTimestamp ?? 0));
+    return {
+      id: `group-${i}`,
+      mediaKeys: items.map((x) => x.mediaKey),
+      originalMediaKey: items[0].mediaKey,
+      similarity: threshold,
+    };
+  });
+
+  return groups.sort((a, b) => b.mediaKeys.length - a.mediaKeys.length);
 }
 
 // ============================================================

--- a/lib/duplicate-detector.ts
+++ b/lib/duplicate-detector.ts
@@ -7,6 +7,8 @@
 // 3. Group duplicates using fast community detection (cosine similarity)
 
 import type { GpdMediaItem, DuplicateGroup } from "./types";
+import { StabilityTracker } from "./scan-log";
+import type { ScanLogger } from "./scan-log";
 
 const MODEL_URL =
   "https://storage.googleapis.com/mediapipe-models/image_embedder/mobilenet_v3_large/float32/latest/mobilenet_v3_large.tflite";
@@ -114,6 +116,16 @@ export interface DetectionProgress {
   total: number;
 }
 
+export interface ScanTiming {
+  totalItems: number;
+  candidates: number;
+  cacheHits: number;
+  fetchThumbnailsMs: number;
+  computeEmbeddingsMs: number;
+  communityDetectionMs: number;
+  totalMs: number;
+}
+
 type ProgressCallback = (progress: DetectionProgress) => void;
 
 // ============================================================
@@ -125,13 +137,28 @@ export async function detectDuplicates(
   threshold: number,
   onProgress?: ProgressCallback,
   signal?: AbortSignal,
-): Promise<DuplicateGroup[]> {
+  logger?: ScanLogger,
+): Promise<{ groups: DuplicateGroup[]; timing: ScanTiming }> {
+  const scanStart = performance.now();
+
   // Filter to items with thumbnails (photos only, skip videos)
   const candidates = mediaItems.filter((item) => item.thumb && !item.duration);
   console.log(
     `[GPD] detectDuplicates: ${mediaItems.length} items → ${candidates.length} candidates`,
   );
-  if (candidates.length < 2) return [];
+
+  const emptyTiming = (extra: Partial<ScanTiming> = {}): ScanTiming => ({
+    totalItems: mediaItems.length,
+    candidates: candidates.length,
+    cacheHits: 0,
+    fetchThumbnailsMs: 0,
+    computeEmbeddingsMs: 0,
+    communityDetectionMs: 0,
+    totalMs: Math.round(performance.now() - scanStart),
+    ...extra,
+  });
+
+  if (candidates.length < 2) return { groups: [], timing: emptyTiming() };
 
   const keys = candidates.map((item) => item.mediaKey);
 
@@ -149,52 +176,89 @@ export async function detectDuplicates(
   const cachedKeySet: Set<string> = db
     ? await loadCachedEmbeddingKeys(db)
     : new Set();
-  if (cachedKeySet.size > 0) {
-    const hits = keys.filter((k) => cachedKeySet.has(k)).length;
-    console.log(
-      `[GPD] embedding cache: ${hits}/${candidates.length} hits, skipping thumbnails`,
-    );
-  }
+  const cacheHits = keys.filter((k) => cachedKeySet.has(k)).length;
+  console.log(
+    `[GPD] embedding cache: ${cacheHits}/${candidates.length} hits, skipping thumbnails`,
+  );
+
+  // Inform logger of candidates/cacheHits now that they're known.
+  // Fire-and-forget — runs concurrently with thumbnail fetching.
+  logger?.updateInfo({ candidates: candidates.length, cacheHits });
+
+  // Wrap onProgress to feed stability tracking alongside the UI callback.
+  const stabilityTracker = new StabilityTracker((est) =>
+    logger?.recordStableEstimate(est),
+  );
+  const trackedProgress: ProgressCallback = (progress) => {
+    onProgress?.(progress);
+    stabilityTracker.update(progress.phase, progress.current, progress.total);
+  };
 
   // Step 1: Download thumbnails — skip items whose embedding is already cached
+  const t1 = performance.now();
   const blobs = await fetchThumbnails(
     candidates,
     cachedKeySet,
-    onProgress,
+    trackedProgress,
     signal,
   );
+  const fetchThumbnailsMs = Math.round(performance.now() - t1);
+  console.log(
+    `[GPD] fetchThumbnails: ${candidates.length - cacheHits} items in ${fetchThumbnailsMs}ms`,
+  );
+  await logger?.phaseComplete("fetchThumbnailsMs", fetchThumbnailsMs);
 
   signal?.throwIfAborted();
 
   // Step 2: Compute embeddings — values loaded in bulk inside computeEmbeddings
+  const t2 = performance.now();
   const { embeddings, validIndices } = await computeEmbeddings(
     blobs,
     keys,
     db,
     cachedKeySet,
-    onProgress,
+    trackedProgress,
     signal,
   );
-  if (embeddings.length < 2) return [];
+  const computeEmbeddingsMs = Math.round(performance.now() - t2);
+  console.log(
+    `[GPD] computeEmbeddings: ${embeddings.length} items (${cacheHits} cached) in ${computeEmbeddingsMs}ms`,
+  );
+  await logger?.phaseComplete("computeEmbeddingsMs", computeEmbeddingsMs);
+
+  if (embeddings.length < 2) {
+    return {
+      groups: [],
+      timing: emptyTiming({ cacheHits, fetchThumbnailsMs, computeEmbeddingsMs }),
+    };
+  }
 
   // Step 3: Community detection — runs in a worker to keep UI responsive.
   // The setTimeout(0) yield lets React flush the phase change to "detecting_duplicates"
   // before the worker is dispatched, so the UI updates before the long computation begins.
   // Progress updates come from the worker during detection.
-  onProgress?.({ phase: "detecting_duplicates", current: 0, total: 0 });
+  trackedProgress({ phase: "detecting_duplicates", current: 0, total: 0 });
   await new Promise<void>((r) => setTimeout(r, 0));
   const workerUrl = chrome.runtime.getURL("scripts/embedder-worker.js");
   const timestamps = validIndices.map(
     (i) => candidates[i].creationTimestamp ?? 0,
   );
+  const t3 = performance.now();
   const indexGroups = await runCommunityDetectionInWorker(
     embeddings,
     threshold,
     timestamps,
     workerUrl,
-    onProgress,
+    trackedProgress,
     signal,
   );
+  const communityDetectionMs = Math.round(performance.now() - t3);
+  const totalMs = Math.round(performance.now() - scanStart);
+  console.log(
+    `[GPD] communityDetection: ${indexGroups.length} groups in ${communityDetectionMs}ms`,
+  );
+  console.log(`[GPD] scan complete: ${totalMs}ms total`);
+  await logger?.phaseComplete("communityDetectionMs", communityDetectionMs);
 
   // Map indices back to media items and build DuplicateGroup objects
   const groups: DuplicateGroup[] = indexGroups.map((indices, i) => {
@@ -211,7 +275,17 @@ export async function detectDuplicates(
     };
   });
 
-  return groups;
+  const timing: ScanTiming = {
+    totalItems: mediaItems.length,
+    candidates: candidates.length,
+    cacheHits,
+    fetchThumbnailsMs,
+    computeEmbeddingsMs,
+    communityDetectionMs,
+    totalMs,
+  };
+
+  return { groups, timing };
 }
 
 // ============================================================

--- a/lib/scan-log.ts
+++ b/lib/scan-log.ts
@@ -17,56 +17,52 @@
 
 export interface StableEstimate {
   /** Phase name (matches DetectionProgress.phase). */
-  phase: string;
+  phase: string
   /** Estimated total duration for this phase in ms. */
-  estimatedMs: number;
+  estimatedMs: number
   /** Progress % through the phase when stability was first reached. */
-  atPercent: number;
+  atPercent: number
 }
 
 export interface PhaseTimings {
-  fetchThumbnailsMs?: number;
-  computeEmbeddingsMs?: number;
-  communityDetectionMs?: number;
+  fetchThumbnailsMs?: number
+  computeEmbeddingsMs?: number
+  communityDetectionMs?: number
 }
 
-export type ScanStatus =
-  | "complete"
-  | "cancelled"
-  | "error"
-  | "killed_by_reload";
+export type ScanStatus = "complete" | "cancelled" | "error" | "killed_by_reload"
 
 export interface ScanLogEntry {
-  timestamp: number;
-  status: ScanStatus;
-  totalItems: number;
+  timestamp: number
+  status: ScanStatus
+  totalItems: number
   /** Photos-only candidates (videos excluded). */
-  candidates: number;
+  candidates: number
   /** Candidates whose embedding was already in the IndexedDB cache. */
-  cacheHits: number;
-  phaseTimings: PhaseTimings;
+  cacheHits: number
+  phaseTimings: PhaseTimings
   /** Wall-clock ms from scan start to termination (success or otherwise). */
-  totalMs: number;
-  groupsFound?: number;
-  error?: string;
-  stableEstimates: StableEstimate[];
+  totalMs: number
+  groupsFound?: number
+  error?: string
+  stableEstimates: StableEstimate[]
 }
 
 // ============================================================
 // Storage keys
 // ============================================================
 
-const ACTIVE_KEY = "scanLogActive";
-const LOG_KEY = "scanLogs";
-const MAX_ENTRIES = 50;
+const ACTIVE_KEY = "scanLogActive"
+const LOG_KEY = "scanLogs"
+const MAX_ENTRIES = 50
 
 interface ActiveScanEntry {
-  startedAt: number;
-  totalItems: number;
-  candidates: number;
-  cacheHits: number;
-  phaseTimings: PhaseTimings;
-  stableEstimates: StableEstimate[];
+  startedAt: number
+  totalItems: number
+  candidates: number
+  cacheHits: number
+  phaseTimings: PhaseTimings
+  stableEstimates: StableEstimate[]
 }
 
 // ============================================================
@@ -83,7 +79,7 @@ interface ActiveScanEntry {
  *   await scanLogger.finalize(...)   // on every exit path
  */
 export class ScanLogger {
-  private active: ActiveScanEntry | null = null;
+  private active: ActiveScanEntry | null = null
 
   /**
    * Call on app mount. If there is an active entry, the page reloaded during a
@@ -91,10 +87,12 @@ export class ScanLogger {
    */
   async recoverStale(): Promise<void> {
     try {
-      const stored = await chrome.storage.local.get(ACTIVE_KEY);
-      const stale = stored[ACTIVE_KEY] as ActiveScanEntry | undefined;
-      if (!stale) return;
-      console.log("[GPD] scan-log: stale active entry found — page reloaded during scan");
+      const stored = await chrome.storage.local.get(ACTIVE_KEY)
+      const stale = stored[ACTIVE_KEY] as ActiveScanEntry | undefined
+      if (!stale) return
+      console.log(
+        "[GPD] scan-log: stale active entry found — page reloaded during scan"
+      )
       await this._commit({
         timestamp: Date.now(),
         status: "killed_by_reload",
@@ -103,8 +101,8 @@ export class ScanLogger {
         cacheHits: stale.cacheHits,
         phaseTimings: stale.phaseTimings,
         totalMs: Date.now() - stale.startedAt,
-        stableEstimates: stale.stableEstimates,
-      });
+        stableEstimates: stale.stableEstimates
+      })
     } catch {
       /* non-critical */
     }
@@ -118,9 +116,11 @@ export class ScanLogger {
       candidates: 0,
       cacheHits: 0,
       phaseTimings: {},
-      stableEstimates: [],
-    };
-    await chrome.storage.local.set({ [ACTIVE_KEY]: this.active }).catch(() => {});
+      stableEstimates: []
+    }
+    await chrome.storage.local
+      .set({ [ACTIVE_KEY]: this.active })
+      .catch(() => {})
   }
 
   /**
@@ -128,34 +128,36 @@ export class ScanLogger {
    * (early in the scan, before thumbnail fetching). Fire-and-forget persist.
    */
   updateInfo(info: { candidates: number; cacheHits: number }): void {
-    if (!this.active) return;
-    this.active.candidates = info.candidates;
-    this.active.cacheHits = info.cacheHits;
-    chrome.storage.local.set({ [ACTIVE_KEY]: this.active }).catch(() => {});
+    if (!this.active) return
+    this.active.candidates = info.candidates
+    this.active.cacheHits = info.cacheHits
+    chrome.storage.local.set({ [ACTIVE_KEY]: this.active }).catch(() => {})
   }
 
   /** Called after each phase completes. Persists so page reloads capture partial data. */
   async phaseComplete(phase: keyof PhaseTimings, ms: number): Promise<void> {
-    if (!this.active) return;
-    this.active.phaseTimings[phase] = ms;
-    await chrome.storage.local.set({ [ACTIVE_KEY]: this.active }).catch(() => {});
+    if (!this.active) return
+    this.active.phaseTimings[phase] = ms
+    await chrome.storage.local
+      .set({ [ACTIVE_KEY]: this.active })
+      .catch(() => {})
   }
 
   /** Called by StabilityTracker when a stable estimate is reached for a phase. */
   recordStableEstimate(est: StableEstimate): void {
-    if (!this.active) return;
-    this.active.stableEstimates.push(est);
-    chrome.storage.local.set({ [ACTIVE_KEY]: this.active }).catch(() => {});
+    if (!this.active) return
+    this.active.stableEstimates.push(est)
+    chrome.storage.local.set({ [ACTIVE_KEY]: this.active }).catch(() => {})
   }
 
   /** Finalize the scan with a terminal status. Must be called on every exit path. */
   async finalize(
     status: ScanStatus,
-    extra: { groupsFound?: number; error?: string } = {},
+    extra: { groupsFound?: number; error?: string } = {}
   ): Promise<void> {
-    if (!this.active) return;
-    const active = this.active;
-    this.active = null;
+    if (!this.active) return
+    const active = this.active
+    this.active = null
     await this._commit({
       timestamp: Date.now(),
       status,
@@ -165,18 +167,18 @@ export class ScanLogger {
       phaseTimings: active.phaseTimings,
       totalMs: Date.now() - active.startedAt,
       stableEstimates: active.stableEstimates,
-      ...extra,
-    });
+      ...extra
+    })
   }
 
   private async _commit(entry: ScanLogEntry): Promise<void> {
     try {
-      const stored = await chrome.storage.local.get(LOG_KEY);
-      const logs: ScanLogEntry[] = stored[LOG_KEY] ?? [];
-      logs.push(entry);
-      if (logs.length > MAX_ENTRIES) logs.splice(0, logs.length - MAX_ENTRIES);
-      await chrome.storage.local.set({ [LOG_KEY]: logs });
-      await chrome.storage.local.remove(ACTIVE_KEY);
+      const stored = await chrome.storage.local.get(LOG_KEY)
+      const logs: ScanLogEntry[] = stored[LOG_KEY] ?? []
+      logs.push(entry)
+      if (logs.length > MAX_ENTRIES) logs.splice(0, logs.length - MAX_ENTRIES)
+      await chrome.storage.local.set({ [LOG_KEY]: logs })
+      await chrome.storage.local.remove(ACTIVE_KEY)
     } catch {
       /* non-critical */
     }
@@ -199,52 +201,52 @@ export class ScanLogger {
  *   tracker.update(progress.phase, progress.current, progress.total)
  */
 export class StabilityTracker {
-  private readonly window: number[] = [];
-  private phaseStart = 0;
-  private lastPhase = "";
-  private readonly firedPhases = new Set<string>();
+  private readonly window: number[] = []
+  private phaseStart = 0
+  private lastPhase = ""
+  private readonly firedPhases = new Set<string>()
 
   constructor(
     private readonly onStable: (est: StableEstimate) => void,
     private readonly windowSize = 3,
     private readonly tolerance = 0.05,
-    private readonly minProgress = 0.1,
+    private readonly minProgress = 0.1
   ) {}
 
   update(phase: string, completed: number, total: number): void {
-    if (total <= 0 || completed <= 0 || this.firedPhases.has(phase)) return;
+    if (total <= 0 || completed <= 0 || this.firedPhases.has(phase)) return
 
     // Reset window on phase transition
     if (phase !== this.lastPhase) {
-      this.lastPhase = phase;
-      this.phaseStart = performance.now();
-      this.window.length = 0;
+      this.lastPhase = phase
+      this.phaseStart = performance.now()
+      this.window.length = 0
     }
 
-    const progress = completed / total;
-    if (progress < this.minProgress) return;
+    const progress = completed / total
+    if (progress < this.minProgress) return
 
-    const elapsedMs = performance.now() - this.phaseStart;
-    this.window.push(elapsedMs / progress);
-    if (this.window.length > this.windowSize) this.window.shift();
-    if (this.window.length < this.windowSize) return;
+    const elapsedMs = performance.now() - this.phaseStart
+    this.window.push(elapsedMs / progress)
+    if (this.window.length > this.windowSize) this.window.shift()
+    if (this.window.length < this.windowSize) return
 
-    const min = Math.min(...this.window);
-    const max = Math.max(...this.window);
-    if (max / min > 1 + this.tolerance) return;
+    const min = Math.min(...this.window)
+    const max = Math.max(...this.window)
+    if (max / min > 1 + this.tolerance) return
 
-    this.firedPhases.add(phase);
-    const sorted = [...this.window].sort((a, b) => a - b);
-    const median = sorted[Math.floor(this.windowSize / 2)];
+    this.firedPhases.add(phase)
+    const sorted = [...this.window].sort((a, b) => a - b)
+    const median = sorted[Math.floor(this.windowSize / 2)]
     const est: StableEstimate = {
       phase,
       estimatedMs: Math.round(median),
-      atPercent: Math.round(progress * 100),
-    };
+      atPercent: Math.round(progress * 100)
+    }
     console.log(
-      `[GPD] stable estimate: ${phase} ~${Math.round(median)}ms (at ${Math.round(progress * 100)}%)`,
-    );
-    this.onStable(est);
+      `[GPD] stable estimate: ${phase} ~${Math.round(median)}ms (at ${Math.round(progress * 100)}%)`
+    )
+    this.onStable(est)
   }
 }
 
@@ -255,9 +257,9 @@ export class StabilityTracker {
 /** Retrieve all stored log entries (oldest first). */
 export async function getScanLogs(): Promise<ScanLogEntry[]> {
   try {
-    const stored = await chrome.storage.local.get(LOG_KEY);
-    return stored[LOG_KEY] ?? [];
+    const stored = await chrome.storage.local.get(LOG_KEY)
+    return stored[LOG_KEY] ?? []
   } catch {
-    return [];
+    return []
   }
 }

--- a/lib/scan-log.ts
+++ b/lib/scan-log.ts
@@ -1,0 +1,263 @@
+// Scan performance and error log — persisted incrementally to chrome.storage.local.
+//
+// chrome.storage.local is backed by LevelDB on disk and survives page reloads,
+// extension reloads, and browser restarts. The active scan is written after each
+// phase so that page reloads are captured even if the scan never completes.
+//
+// Reading logs from the extension console:
+//   chrome.storage.local.get("scanLogs", console.log)
+//
+// Exporting to a file (run in the extension console):
+//   chrome.storage.local.get("scanLogs", ({ scanLogs }) => {
+//     const a = document.createElement("a")
+//     a.href = URL.createObjectURL(new Blob([JSON.stringify(scanLogs, null, 2)], { type: "application/json" }))
+//     a.download = "gpd-scan-logs.json"
+//     a.click()
+//   })
+
+export interface StableEstimate {
+  /** Phase name (matches DetectionProgress.phase). */
+  phase: string;
+  /** Estimated total duration for this phase in ms. */
+  estimatedMs: number;
+  /** Progress % through the phase when stability was first reached. */
+  atPercent: number;
+}
+
+export interface PhaseTimings {
+  fetchThumbnailsMs?: number;
+  computeEmbeddingsMs?: number;
+  communityDetectionMs?: number;
+}
+
+export type ScanStatus =
+  | "complete"
+  | "cancelled"
+  | "error"
+  | "killed_by_reload";
+
+export interface ScanLogEntry {
+  timestamp: number;
+  status: ScanStatus;
+  totalItems: number;
+  /** Photos-only candidates (videos excluded). */
+  candidates: number;
+  /** Candidates whose embedding was already in the IndexedDB cache. */
+  cacheHits: number;
+  phaseTimings: PhaseTimings;
+  /** Wall-clock ms from scan start to termination (success or otherwise). */
+  totalMs: number;
+  groupsFound?: number;
+  error?: string;
+  stableEstimates: StableEstimate[];
+}
+
+// ============================================================
+// Storage keys
+// ============================================================
+
+const ACTIVE_KEY = "scanLogActive";
+const LOG_KEY = "scanLogs";
+const MAX_ENTRIES = 50;
+
+interface ActiveScanEntry {
+  startedAt: number;
+  totalItems: number;
+  candidates: number;
+  cacheHits: number;
+  phaseTimings: PhaseTimings;
+  stableEstimates: StableEstimate[];
+}
+
+// ============================================================
+// ScanLogger
+// ============================================================
+
+/**
+ * Incrementally persists scan progress to chrome.storage.local.
+ *
+ * Lifecycle:
+ *   scanLogger.recoverStale()        // on app mount — salvage any reload victim
+ *   await scanLogger.start(n)        // before detectDuplicates
+ *   // (detectDuplicates calls updateInfo / phaseComplete / recordStableEstimate)
+ *   await scanLogger.finalize(...)   // on every exit path
+ */
+export class ScanLogger {
+  private active: ActiveScanEntry | null = null;
+
+  /**
+   * Call on app mount. If there is an active entry, the page reloaded during a
+   * scan — commit it as "killed_by_reload" so the partial data is not lost.
+   */
+  async recoverStale(): Promise<void> {
+    try {
+      const stored = await chrome.storage.local.get(ACTIVE_KEY);
+      const stale = stored[ACTIVE_KEY] as ActiveScanEntry | undefined;
+      if (!stale) return;
+      console.log("[GPD] scan-log: stale active entry found — page reloaded during scan");
+      await this._commit({
+        timestamp: Date.now(),
+        status: "killed_by_reload",
+        totalItems: stale.totalItems,
+        candidates: stale.candidates,
+        cacheHits: stale.cacheHits,
+        phaseTimings: stale.phaseTimings,
+        totalMs: Date.now() - stale.startedAt,
+        stableEstimates: stale.stableEstimates,
+      });
+    } catch {
+      /* non-critical */
+    }
+  }
+
+  /** Start a new active entry. Call before detectDuplicates. */
+  async start(totalItems: number): Promise<void> {
+    this.active = {
+      startedAt: Date.now(),
+      totalItems,
+      candidates: 0,
+      cacheHits: 0,
+      phaseTimings: {},
+      stableEstimates: [],
+    };
+    await chrome.storage.local.set({ [ACTIVE_KEY]: this.active }).catch(() => {});
+  }
+
+  /**
+   * Update candidates/cacheHits once detectDuplicates has computed them
+   * (early in the scan, before thumbnail fetching). Fire-and-forget persist.
+   */
+  updateInfo(info: { candidates: number; cacheHits: number }): void {
+    if (!this.active) return;
+    this.active.candidates = info.candidates;
+    this.active.cacheHits = info.cacheHits;
+    chrome.storage.local.set({ [ACTIVE_KEY]: this.active }).catch(() => {});
+  }
+
+  /** Called after each phase completes. Persists so page reloads capture partial data. */
+  async phaseComplete(phase: keyof PhaseTimings, ms: number): Promise<void> {
+    if (!this.active) return;
+    this.active.phaseTimings[phase] = ms;
+    await chrome.storage.local.set({ [ACTIVE_KEY]: this.active }).catch(() => {});
+  }
+
+  /** Called by StabilityTracker when a stable estimate is reached for a phase. */
+  recordStableEstimate(est: StableEstimate): void {
+    if (!this.active) return;
+    this.active.stableEstimates.push(est);
+    chrome.storage.local.set({ [ACTIVE_KEY]: this.active }).catch(() => {});
+  }
+
+  /** Finalize the scan with a terminal status. Must be called on every exit path. */
+  async finalize(
+    status: ScanStatus,
+    extra: { groupsFound?: number; error?: string } = {},
+  ): Promise<void> {
+    if (!this.active) return;
+    const active = this.active;
+    this.active = null;
+    await this._commit({
+      timestamp: Date.now(),
+      status,
+      totalItems: active.totalItems,
+      candidates: active.candidates,
+      cacheHits: active.cacheHits,
+      phaseTimings: active.phaseTimings,
+      totalMs: Date.now() - active.startedAt,
+      stableEstimates: active.stableEstimates,
+      ...extra,
+    });
+  }
+
+  private async _commit(entry: ScanLogEntry): Promise<void> {
+    try {
+      const stored = await chrome.storage.local.get(LOG_KEY);
+      const logs: ScanLogEntry[] = stored[LOG_KEY] ?? [];
+      logs.push(entry);
+      if (logs.length > MAX_ENTRIES) logs.splice(0, logs.length - MAX_ENTRIES);
+      await chrome.storage.local.set({ [LOG_KEY]: logs });
+      await chrome.storage.local.remove(ACTIVE_KEY);
+    } catch {
+      /* non-critical */
+    }
+  }
+}
+
+// ============================================================
+// StabilityTracker
+// ============================================================
+
+/**
+ * Wraps onProgress events and fires onStable once three consecutive
+ * projected-total-duration estimates for a phase are within `tolerance`
+ * of each other (default 5%). Requires ≥ `minProgress` completion (default 10%)
+ * before the window starts, to avoid noise from early samples.
+ *
+ * Usage inside detectDuplicates:
+ *   const tracker = new StabilityTracker((est) => logger?.recordStableEstimate(est))
+ *   // then in the wrapped onProgress:
+ *   tracker.update(progress.phase, progress.current, progress.total)
+ */
+export class StabilityTracker {
+  private readonly window: number[] = [];
+  private phaseStart = 0;
+  private lastPhase = "";
+  private readonly firedPhases = new Set<string>();
+
+  constructor(
+    private readonly onStable: (est: StableEstimate) => void,
+    private readonly windowSize = 3,
+    private readonly tolerance = 0.05,
+    private readonly minProgress = 0.1,
+  ) {}
+
+  update(phase: string, completed: number, total: number): void {
+    if (total <= 0 || completed <= 0 || this.firedPhases.has(phase)) return;
+
+    // Reset window on phase transition
+    if (phase !== this.lastPhase) {
+      this.lastPhase = phase;
+      this.phaseStart = performance.now();
+      this.window.length = 0;
+    }
+
+    const progress = completed / total;
+    if (progress < this.minProgress) return;
+
+    const elapsedMs = performance.now() - this.phaseStart;
+    this.window.push(elapsedMs / progress);
+    if (this.window.length > this.windowSize) this.window.shift();
+    if (this.window.length < this.windowSize) return;
+
+    const min = Math.min(...this.window);
+    const max = Math.max(...this.window);
+    if (max / min > 1 + this.tolerance) return;
+
+    this.firedPhases.add(phase);
+    const sorted = [...this.window].sort((a, b) => a - b);
+    const median = sorted[Math.floor(this.windowSize / 2)];
+    const est: StableEstimate = {
+      phase,
+      estimatedMs: Math.round(median),
+      atPercent: Math.round(progress * 100),
+    };
+    console.log(
+      `[GPD] stable estimate: ${phase} ~${Math.round(median)}ms (at ${Math.round(progress * 100)}%)`,
+    );
+    this.onStable(est);
+  }
+}
+
+// ============================================================
+// Query
+// ============================================================
+
+/** Retrieve all stored log entries (oldest first). */
+export async function getScanLogs(): Promise<ScanLogEntry[]> {
+  try {
+    const stored = await chrome.storage.local.get(LOG_KEY);
+    return stored[LOG_KEY] ?? [];
+  } catch {
+    return [];
+  }
+}

--- a/lib/scan-results.ts
+++ b/lib/scan-results.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns true if stored scan results are valid for the given context.
+ * Used by both the UI (mount load, incremental cache) and the reducer
+ * (health check) so future invalidation conditions only need to be added here.
+ */
+export function areScanResultsValid(
+  stored: { accountEmail?: string },
+  context: { accountEmail?: string },
+): boolean {
+  // Account mismatch: results belong to a different account
+  if (stored.accountEmail && context.accountEmail && stored.accountEmail !== context.accountEmail)
+    return false;
+  return true;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -39,8 +39,11 @@ export interface ScanLibraryMessage extends BaseMessage {
   options: ScanOptions;
 }
 
+export type ScanMode = "smart" | "full"
+
 export interface ScanOptions {
   similarityThreshold: number; // 0.90 - 1.00
+  scanMode: ScanMode;
   dateRange?: {
     from?: string; // ISO date string
     to?: string;
@@ -186,6 +189,7 @@ export interface StoredState {
 
 export interface ScanSettings {
   similarityThreshold: number;
+  scanMode: ScanMode;
   dateRange?: {
     from?: string;
     to?: string;
@@ -194,4 +198,5 @@ export interface ScanSettings {
 
 export const DEFAULT_SETTINGS: ScanSettings = {
   similarityThreshold: 0.99,
+  scanMode: "smart",
 };

--- a/scripts/embedder-worker.js
+++ b/scripts/embedder-worker.js
@@ -4065,6 +4065,41 @@
       );
       self.postMessage({ type: "detectionResults", groups });
     }
+    if (type === "detectSmart") {
+      const { flatEmbeddings, n: n2, dim, threshold, buckets } = data;
+      const embeddings = [];
+      for (let i2 = 0; i2 < n2; i2++)
+        embeddings.push(flatEmbeddings.subarray(i2 * dim, (i2 + 1) * dim));
+      const allGroups = [];
+      for (let bi2 = 0; bi2 < buckets.length; bi2++) {
+        const bucket = buckets[bi2];
+        const parent = bucket.map((_2, j2) => j2);
+        const find = (x2) => parent[x2] === x2 ? x2 : parent[x2] = find(parent[x2]);
+        const union = (a2, b2) => {
+          parent[find(a2)] = find(b2);
+        };
+        for (let i2 = 0; i2 < bucket.length; i2++) {
+          for (let j2 = i2 + 1; j2 < bucket.length; j2++) {
+            const a2 = embeddings[bucket[i2]];
+            const b2 = embeddings[bucket[j2]];
+            let dot = 0;
+            for (let k2 = 0; k2 < dim; k2++) dot += a2[k2] * b2[k2];
+            if (dot >= threshold) union(i2, j2);
+          }
+        }
+        const components = /* @__PURE__ */ new Map();
+        for (let i2 = 0; i2 < bucket.length; i2++) {
+          const root = find(i2);
+          if (!components.has(root)) components.set(root, []);
+          components.get(root).push(bucket[i2]);
+        }
+        for (const [, members] of components)
+          if (members.length >= 2) allGroups.push(members);
+        if (bi2 % 100 === 0)
+          self.postMessage({ type: "detectionProgress", current: bi2 + 1, total: buckets.length });
+      }
+      self.postMessage({ type: "detectionResults", groups: allGroups });
+    }
   });
   async function workerCommunityDetection(embeddings, threshold, timestamps, onProgress) {
     const n2 = embeddings.length;

--- a/scripts/embedder-worker.js
+++ b/scripts/embedder-worker.js
@@ -4101,34 +4101,77 @@
       self.postMessage({ type: "detectionResults", groups: allGroups });
     }
   });
-  async function workerCommunityDetection(embeddings, threshold, timestamps, onProgress) {
+  async function workerCommunityDetection(embeddings, threshold, _timestamps, onProgress) {
     const n2 = embeddings.length;
     const dim = embeddings[0].length;
-    const order = Array.from({ length: n2 }, (_2, i2) => i2);
-    if (timestamps) {
-      order.sort((a2, b2) => (timestamps[a2] ?? 0) - (timestamps[b2] ?? 0));
-    }
-    const sorted = order.map((i2) => embeddings[i2]);
-    const groups = [];
-    let currentGroup = [order[0]];
-    for (let i2 = 0; i2 < n2 - 1; i2++) {
-      const a2 = sorted[i2];
-      const b2 = sorted[i2 + 1];
-      let dot = 0;
-      for (let k2 = 0; k2 < dim; k2++) dot += a2[k2] * b2[k2];
-      if (dot >= threshold) {
-        currentGroup.push(order[i2 + 1]);
-      } else {
-        if (currentGroup.length >= 2) groups.push(currentGroup);
-        currentGroup = [order[i2 + 1]];
+    const batchSize = 128;
+    const minCommunitySize = 2;
+    const extractedCommunities = [];
+    let sortMaxSize = Math.min(Math.max(2 * minCommunitySize, 50), n2);
+    for (let startIdx = 0; startIdx < n2; startIdx += batchSize) {
+      const endIdx = Math.min(startIdx + batchSize, n2);
+      const batchLen = endIdx - startIdx;
+      const cosScores = matMul(embeddings, startIdx, endIdx, embeddings, 0, n2, dim);
+      for (let i2 = 0; i2 < batchLen; i2++) {
+        const row = cosScores.subarray(i2 * n2, (i2 + 1) * n2);
+        const topKMin = topK(row, minCommunitySize);
+        if (topKMin.values[topKMin.values.length - 1] < threshold) continue;
+        let topKResult = topK(row, sortMaxSize);
+        while (topKResult.values[topKResult.values.length - 1] > threshold && sortMaxSize < n2) {
+          sortMaxSize = Math.min(2 * sortMaxSize, n2);
+          topKResult = topK(row, sortMaxSize);
+        }
+        const cluster = [];
+        for (let j2 = 0; j2 < topKResult.values.length; j2++) {
+          if (topKResult.values[j2] < threshold) break;
+          cluster.push(topKResult.indices[j2]);
+        }
+        if (cluster.length >= minCommunitySize) {
+          extractedCommunities.push(cluster);
+        }
       }
-      if (i2 % 500 === 0) {
-        onProgress?.(i2 + 1, n2);
-        await new Promise((resolve) => setTimeout(resolve, 0));
+      onProgress?.(endIdx, n2);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    extractedCommunities.sort((a2, b2) => b2.length - a2.length);
+    const uniqueCommunities = [];
+    const assignedIds = /* @__PURE__ */ new Set();
+    for (const community of extractedCommunities) {
+      const nonOverlapping = community.slice().sort((a2, b2) => a2 - b2).filter((idx) => !assignedIds.has(idx));
+      if (nonOverlapping.length >= minCommunitySize) {
+        uniqueCommunities.push(nonOverlapping);
+        for (const idx of nonOverlapping) assignedIds.add(idx);
       }
     }
-    if (currentGroup.length >= 2) groups.push(currentGroup);
-    groups.sort((a2, b2) => b2.length - a2.length);
-    return groups;
+    uniqueCommunities.sort((a2, b2) => b2.length - a2.length);
+    return uniqueCommunities;
+  }
+  function matMul(A2, startA, endA, B2, startB, endB, dim) {
+    const rowsA = endA - startA;
+    const rowsB = endB - startB;
+    const result = new Float32Array(rowsA * rowsB);
+    for (let i2 = 0; i2 < rowsA; i2++) {
+      const aRow = A2[startA + i2];
+      for (let j2 = 0; j2 < rowsB; j2++) {
+        const bRow = B2[startB + j2];
+        let dot = 0;
+        for (let k2 = 0; k2 < dim; k2++) dot += aRow[k2] * bRow[k2];
+        result[i2 * rowsB + j2] = dot;
+      }
+    }
+    return result;
+  }
+  function topK(arr, k2) {
+    k2 = Math.min(k2, arr.length);
+    const indexed = [];
+    for (let i2 = 0; i2 < arr.length; i2++) indexed.push({ val: arr[i2], idx: i2 });
+    indexed.sort((a2, b2) => b2.val - a2.val);
+    const values = [];
+    const indices = [];
+    for (let i2 = 0; i2 < k2; i2++) {
+      values.push(indexed[i2].val);
+      indices.push(indexed[i2].idx);
+    }
+    return { values, indices };
   }
 })();

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -20,7 +20,7 @@ import { ThemeProvider } from "@mui/material/styles";
 import theme from "../lib/theme";
 import { APP_ID } from "../lib/types";
 import { debug } from "../lib/debug";
-import { detectDuplicates } from "../lib/duplicate-detector";
+import { fullDetectDuplicates, smartDetectDuplicates } from "../lib/duplicate-detector";
 import type { DetectionProgress } from "../lib/duplicate-detector";
 import { ScanLogger } from "../lib/scan-log";
 import { appReducer } from "../lib/app-reducer";
@@ -260,25 +260,39 @@ export default function App() {
       const logger = scanLoggerRef.current;
       await logger.start(items.length);
       try {
-        const { groups } = await detectDuplicates(
-          items,
-          settingsRef.current.similarityThreshold,
-          (progress: DetectionProgress) => {
-            dispatch({
-              type: "SCAN_PROGRESS",
-              phase: progress.phase,
-              payload: {
-                app: APP_ID,
-                action: "gptkProgress",
-                requestId: "",
-                itemsProcessed: progress.current,
-                message: `${progress.phase}: ${progress.current}/${progress.total}`,
-              },
-            });
-          },
-          signal,
-          logger,
-        );
+        const onProgressCallback = (progress: DetectionProgress) => {
+          dispatch({
+            type: "SCAN_PROGRESS",
+            phase: progress.phase,
+            payload: {
+              app: APP_ID,
+              action: "gptkProgress",
+              requestId: "",
+              itemsProcessed: progress.current,
+              message: `${progress.phase}: ${progress.current}/${progress.total}`,
+            },
+          });
+        };
+
+        const groups =
+          settingsRef.current.scanMode === "smart"
+            ? await smartDetectDuplicates(
+                items,
+                settingsRef.current.similarityThreshold,
+                0,
+                onProgressCallback,
+                signal,
+              )
+            : await (async () => {
+                const result = await fullDetectDuplicates(
+                  items,
+                  settingsRef.current.similarityThreshold,
+                  onProgressCallback,
+                  signal,
+                  logger,
+                );
+                return result.groups;
+              })();
 
         await logger.finalize("complete", { groupsFound: groups.length });
 

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -112,6 +112,10 @@ export default function App() {
   // Cached media items from previous scan, used to merge with incremental fetch
   const cachedMediaItemsRef = useRef<Record<string, GpdMediaItem> | null>(null)
 
+  // Tracks the requestId of the active scan so stale results from previous
+  // scans killed by reload can be dropped (they arrive late from the GP tab)
+  const currentScanRequestIdRef = useRef<string | null>(null)
+
   // Sync selectedGroupIds when groups change (e.g. after scan or trash)
   const stateGroups =
     state.status === "results" || state.status === "trashing"
@@ -179,6 +183,14 @@ export default function App() {
         case "gptkResult": {
           const result = message as GptkResultMessage
           if (result.command === "getAllMediaItems") {
+            // Drop stale results from scans that were killed/cancelled — their
+            // GPTK request may have still been in-flight and arrives late
+            if (result.requestId !== currentScanRequestIdRef.current) {
+              console.warn(
+                `[GPD] Dropping stale getAllMediaItems result for requestId ${result.requestId} (active: ${currentScanRequestIdRef.current})`
+              )
+              break
+            }
             if (result.success) {
               let items = result.data as GpdMediaItem[]
               const cached = cachedMediaItemsRef.current
@@ -290,7 +302,8 @@ export default function App() {
                 settingsRef.current.similarityThreshold,
                 1000,
                 onProgressCallback,
-                signal
+                signal,
+                logger
               )
             : await (async () => {
                 const result = await fullDetectDuplicates(
@@ -304,6 +317,7 @@ export default function App() {
               })()
 
         await logger.finalize("complete", { groupsFound: groups.length })
+        currentScanRequestIdRef.current = null
 
         const mediaItemMap: Record<string, GpdMediaItem> = {}
         for (const item of items) {
@@ -316,6 +330,7 @@ export default function App() {
           groups
         })
       } catch (error) {
+        currentScanRequestIdRef.current = null
         if (error instanceof DOMException && error.name === "AbortError") {
           await logger.finalize("cancelled")
           dispatch({ type: "SCAN_CANCELLED" })
@@ -394,6 +409,7 @@ export default function App() {
     scanAbortRef.current = new AbortController()
 
     const requestId = generateRequestId()
+    currentScanRequestIdRef.current = requestId
     const hasGptk = state.status === "connected" ? state.hasGptk : true
     const accountEmail =
       state.status === "connected" || state.status === "results"
@@ -495,6 +511,7 @@ export default function App() {
 
   const handleCancelScan = useCallback(() => {
     scanAbortRef.current?.abort()
+    currentScanRequestIdRef.current = null
     dispatch({ type: "SCAN_CANCELLED" })
   }, [])
 

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -22,6 +22,7 @@ import { APP_ID } from "../lib/types";
 import { debug } from "../lib/debug";
 import { detectDuplicates } from "../lib/duplicate-detector";
 import type { DetectionProgress } from "../lib/duplicate-detector";
+import { ScanLogger } from "../lib/scan-log";
 import { appReducer } from "../lib/app-reducer";
 import type { AppState, AppAction } from "../lib/app-reducer";
 import type {
@@ -100,6 +101,9 @@ export default function App() {
 
   // AbortController for the current scan (cancelled on user request or new scan)
   const scanAbortRef = useRef<AbortController | null>(null);
+
+  // Persisted scan performance logger — survives page reloads via chrome.storage.local
+  const scanLoggerRef = useRef(new ScanLogger());
 
   // Cached media items from previous scan, used to merge with incremental fetch
   const cachedMediaItemsRef = useRef<Record<string, GpdMediaItem> | null>(null);
@@ -253,8 +257,10 @@ export default function App() {
   // Run MediaPipe duplicate detection on fetched media items
   const runDuplicateDetection = useCallback(
     async (items: GpdMediaItem[], signal: AbortSignal) => {
+      const logger = scanLoggerRef.current;
+      await logger.start(items.length);
       try {
-        const groups = await detectDuplicates(
+        const { groups } = await detectDuplicates(
           items,
           settingsRef.current.similarityThreshold,
           (progress: DetectionProgress) => {
@@ -271,7 +277,10 @@ export default function App() {
             });
           },
           signal,
+          logger,
         );
+
+        await logger.finalize("complete", { groupsFound: groups.length });
 
         const mediaItemMap: Record<string, GpdMediaItem> = {};
         for (const item of items) {
@@ -285,8 +294,10 @@ export default function App() {
         });
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
+          await logger.finalize("cancelled");
           dispatch({ type: "SCAN_CANCELLED" });
         } else {
+          await logger.finalize("error", { error: String(error) });
           dispatch({
             type: "SCAN_ERROR",
             error: `Duplicate detection failed: ${error}`,
@@ -297,9 +308,10 @@ export default function App() {
     [],
   );
 
-  // Health check on mount
+  // Health check on mount + recover any scan log entry orphaned by a page reload
   useEffect(() => {
     sendToServiceWorker({ app: APP_ID, action: "healthCheck" });
+    scanLoggerRef.current.recoverStale();
   }, []);
 
   // Load saved settings and results on mount

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -345,7 +345,7 @@ export default function App() {
         if (result.settings) {
           setSettings(result.settings)
         }
-        if (result.scanResults?.totalItems && result.scanResults.groups?.length > 0) {
+        if (result.scanResults?.totalItems && Array.isArray(result.scanResults.groups)) {
           dispatch({
             type: "LOAD_SAVED_RESULTS",
             mediaItems: result.scanResults.mediaItems,

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -279,6 +279,10 @@ export default function App() {
           })
         }
 
+        console.log(
+          `[GPD] starting scan: mode=${settingsRef.current.scanMode}, threshold=${settingsRef.current.similarityThreshold}`
+        )
+
         const groups =
           settingsRef.current.scanMode === "smart"
             ? await smartDetectDuplicates(

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -1,56 +1,59 @@
-import { useEffect, useReducer, useCallback, useRef, useState } from "react";
-import confetti from "canvas-confetti";
-import Alert from "@mui/material/Alert";
-import AppBar from "@mui/material/AppBar";
-import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
-import CircularProgress from "@mui/material/CircularProgress";
-import CssBaseline from "@mui/material/CssBaseline";
-import Dialog from "@mui/material/Dialog";
-import DialogActions from "@mui/material/DialogActions";
-import DialogContent from "@mui/material/DialogContent";
-import DialogContentText from "@mui/material/DialogContentText";
-import DialogTitle from "@mui/material/DialogTitle";
-import IconButton from "@mui/material/IconButton";
-import Snackbar from "@mui/material/Snackbar";
-import Toolbar from "@mui/material/Toolbar";
-import Typography from "@mui/material/Typography";
-import CloseIcon from "@mui/icons-material/Close";
-import { ThemeProvider } from "@mui/material/styles";
-import theme from "../lib/theme";
-import { APP_ID } from "../lib/types";
-import { debug } from "../lib/debug";
-import { fullDetectDuplicates, smartDetectDuplicates } from "../lib/duplicate-detector";
-import type { DetectionProgress } from "../lib/duplicate-detector";
-import { ScanLogger } from "../lib/scan-log";
-import { appReducer } from "../lib/app-reducer";
-import type { AppState, AppAction } from "../lib/app-reducer";
+import CloseIcon from "@mui/icons-material/Close"
+import Alert from "@mui/material/Alert"
+import AppBar from "@mui/material/AppBar"
+import Box from "@mui/material/Box"
+import Button from "@mui/material/Button"
+import CircularProgress from "@mui/material/CircularProgress"
+import CssBaseline from "@mui/material/CssBaseline"
+import Dialog from "@mui/material/Dialog"
+import DialogActions from "@mui/material/DialogActions"
+import DialogContent from "@mui/material/DialogContent"
+import DialogContentText from "@mui/material/DialogContentText"
+import DialogTitle from "@mui/material/DialogTitle"
+import IconButton from "@mui/material/IconButton"
+import Snackbar from "@mui/material/Snackbar"
+import { ThemeProvider } from "@mui/material/styles"
+import Toolbar from "@mui/material/Toolbar"
+import Typography from "@mui/material/Typography"
+import confetti from "canvas-confetti"
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react"
+
+import { ActionBar } from "../components/ActionBar"
+import { DuplicateGroups } from "../components/DuplicateGroups"
+import { ScanConfig } from "../components/ScanConfig"
+import { ScanProgress } from "../components/ScanProgress"
+import { appReducer } from "../lib/app-reducer"
+import type { AppAction, AppState } from "../lib/app-reducer"
+import { debug } from "../lib/debug"
+import {
+  fullDetectDuplicates,
+  smartDetectDuplicates
+} from "../lib/duplicate-detector"
+import type { DetectionProgress } from "../lib/duplicate-detector"
+import { ScanLogger } from "../lib/scan-log"
+import theme from "../lib/theme"
+import { APP_ID, DEFAULT_SETTINGS } from "../lib/types"
 import type {
   AppMessage,
-  GpdMediaItem,
   DuplicateGroup,
-  ScanSettings,
-  HealthCheckResultMessage,
-  GptkResultMessage,
+  GpdMediaItem,
   GptkProgressMessage,
-  StoredState,
-} from "../lib/types";
-import { DEFAULT_SETTINGS } from "../lib/types";
-import { ScanConfig } from "../components/ScanConfig";
-import { ScanProgress } from "../components/ScanProgress";
-import { DuplicateGroups } from "../components/DuplicateGroups";
-import { ActionBar } from "../components/ActionBar";
+  GptkResultMessage,
+  HealthCheckResultMessage,
+  ScanSettings,
+  StoredState
+} from "../lib/types"
 
 // ============================================================
 // Helpers
 // ============================================================
 
 function generateRequestId(): string {
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 }
 
 function sendToServiceWorker(message: AppMessage): void {
-  chrome.runtime.sendMessage(message);
+  chrome.runtime.sendMessage(message)
 }
 
 // ============================================================
@@ -58,207 +61,209 @@ function sendToServiceWorker(message: AppMessage): void {
 // ============================================================
 
 export default function App() {
-  const [state, dispatch] = useReducer(appReducer, { status: "connecting" });
+  const [state, dispatch] = useReducer(appReducer, { status: "connecting" })
+  const [storageChecked, setStorageChecked] = useState(false)
   const [settings, setSettings] = useReducer(
     (prev: ScanSettings, next: Partial<ScanSettings>) => ({ ...prev, ...next }),
-    DEFAULT_SETTINGS,
-  );
+    DEFAULT_SETTINGS
+  )
 
   // Selection state: which groups are selected for trash
   const [selectedGroupIds, setSelectedGroupIds] = useState<Set<string>>(
-    new Set(),
-  );
+    new Set()
+  )
 
   // Kept overrides: groupId -> Set of mediaKeys the user marked as "Keep"
   const [keptOverrides, setKeptOverrides] = useState<
     Record<string, Set<string>>
-  >({});
+  >({})
 
   // Confirm dialog state
   const [trashConfirm, setTrashConfirm] = useState<{
-    dedupKeys: string[];
-    mediaKeysToTrash: string[];
-  } | null>(null);
+    dedupKeys: string[]
+    mediaKeysToTrash: string[]
+  } | null>(null)
 
   // Undo trash state: stored after a successful trash operation
   const [undoData, setUndoData] = useState<{
-    dedupKeys: string[];
-    count: number;
+    dedupKeys: string[]
+    count: number
     snapshot: {
-      mediaItems: Record<string, GpdMediaItem>;
-      groups: DuplicateGroup[];
-      totalItems: number;
-    };
-  } | null>(null);
+      mediaItems: Record<string, GpdMediaItem>
+      groups: DuplicateGroup[]
+      totalItems: number
+    }
+  } | null>(null)
 
   // Refs to capture pre-trash data for undo
   const preTrashSnapshotRef = useRef<{
-    mediaItems: Record<string, GpdMediaItem>;
-    groups: DuplicateGroup[];
-    totalItems: number;
-  } | null>(null);
-  const pendingDedupKeysRef = useRef<string[] | null>(null);
+    mediaItems: Record<string, GpdMediaItem>
+    groups: DuplicateGroup[]
+    totalItems: number
+  } | null>(null)
+  const pendingDedupKeysRef = useRef<string[] | null>(null)
 
   // AbortController for the current scan (cancelled on user request or new scan)
-  const scanAbortRef = useRef<AbortController | null>(null);
+  const scanAbortRef = useRef<AbortController | null>(null)
 
   // Persisted scan performance logger — survives page reloads via chrome.storage.local
-  const scanLoggerRef = useRef(new ScanLogger());
+  const scanLoggerRef = useRef(new ScanLogger())
 
   // Cached media items from previous scan, used to merge with incremental fetch
-  const cachedMediaItemsRef = useRef<Record<string, GpdMediaItem> | null>(null);
+  const cachedMediaItemsRef = useRef<Record<string, GpdMediaItem> | null>(null)
 
   // Sync selectedGroupIds when groups change (e.g. after scan or trash)
-  const groups =
+  const stateGroups =
     state.status === "results" || state.status === "trashing"
       ? state.groups
-      : [];
+      : null
+  const groups = useMemo(() => stateGroups ?? [], [stateGroups])
   useEffect(() => {
-    setSelectedGroupIds(new Set(groups.map((g) => g.id)));
-    setKeptOverrides({});
-  }, [groups]);
+    setSelectedGroupIds(new Set(groups.map((g) => g.id)))
+    setKeptOverrides({})
+  }, [groups])
 
   const getKept = useCallback(
     (group: DuplicateGroup): Set<string> =>
       keptOverrides[group.id] ?? new Set([group.originalMediaKey]),
-    [keptOverrides],
-  );
+    [keptOverrides]
+  )
 
   const handleToggleKept = useCallback(
     (group: DuplicateGroup, mediaKey: string) => {
       setKeptOverrides((prev) => {
-        const current = prev[group.id] ?? new Set([group.originalMediaKey]);
+        const current = prev[group.id] ?? new Set([group.originalMediaKey])
         // Prevent removing the last kept item
-        if (current.has(mediaKey) && current.size === 1) return prev;
-        const next = new Set(current);
+        if (current.has(mediaKey) && current.size === 1) return prev
+        const next = new Set(current)
         if (next.has(mediaKey)) {
-          next.delete(mediaKey);
+          next.delete(mediaKey)
         } else {
-          next.add(mediaKey);
+          next.add(mediaKey)
         }
-        return { ...prev, [group.id]: next };
-      });
+        return { ...prev, [group.id]: next }
+      })
     },
-    [],
-  );
+    []
+  )
 
   const handleToggleGroup = useCallback((groupId: string) => {
     setSelectedGroupIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(groupId)) next.delete(groupId);
-      else next.add(groupId);
-      return next;
-    });
-  }, []);
+      const next = new Set(prev)
+      if (next.has(groupId)) next.delete(groupId)
+      else next.add(groupId)
+      return next
+    })
+  }, [])
 
   const handleSelectAll = useCallback(() => {
-    setSelectedGroupIds(new Set(groups.map((g) => g.id)));
-  }, [groups]);
+    setSelectedGroupIds(new Set(groups.map((g) => g.id)))
+  }, [groups])
 
   const handleDeselectAll = useCallback(() => {
-    setSelectedGroupIds(new Set());
-  }, []);
+    setSelectedGroupIds(new Set())
+  }, [])
 
   // Listen for messages from service worker
   useEffect(() => {
     const listener = (message: AppMessage) => {
-      if (message?.app !== APP_ID) return;
+      if (message?.app !== APP_ID) return
 
       switch (message.action) {
         case "healthCheck.result":
           dispatch({
             type: "HEALTH_CHECK_RESULT",
-            payload: message as HealthCheckResultMessage,
-          });
-          break;
+            payload: message as HealthCheckResultMessage
+          })
+          break
         case "gptkResult": {
-          const result = message as GptkResultMessage;
+          const result = message as GptkResultMessage
           if (result.command === "getAllMediaItems") {
             if (result.success) {
-              let items = result.data as GpdMediaItem[];
-              const cached = cachedMediaItemsRef.current;
+              let items = result.data as GpdMediaItem[]
+              const cached = cachedMediaItemsRef.current
               if (cached && Object.keys(cached).length > 0) {
                 // Merge: new items take precedence over cached (handles field updates)
-                const newItemKeys = new Set(items.map((i) => i.mediaKey));
+                const newItemKeys = new Set(items.map((i) => i.mediaKey))
                 const cachedOnly = Object.values(cached).filter(
-                  (i) => !newItemKeys.has(i.mediaKey),
-                );
-                items = [...items, ...cachedOnly];
+                  (i) => !newItemKeys.has(i.mediaKey)
+                )
+                items = [...items, ...cachedOnly]
                 console.log(
-                  `[GPD] media items: ${(result.data as GpdMediaItem[]).length} new + ${cachedOnly.length} cached = ${items.length} total`,
-                );
-                cachedMediaItemsRef.current = null;
+                  `[GPD] media items: ${(result.data as GpdMediaItem[]).length} new + ${cachedOnly.length} cached = ${items.length} total`
+                )
+                cachedMediaItemsRef.current = null
               }
               dispatch({
                 type: "SCAN_MEDIA_FETCHED",
-                mediaItems: items,
-              });
+                mediaItems: items
+              })
               runDuplicateDetection(
                 items,
-                scanAbortRef.current?.signal ?? new AbortController().signal,
-              );
+                scanAbortRef.current?.signal ?? new AbortController().signal
+              )
             } else {
               dispatch({
                 type: "SCAN_ERROR",
-                error: result.error || "Scan failed",
-              });
+                error: result.error || "Scan failed"
+              })
             }
           } else if (result.command === "trashItems") {
             if (result.success) {
-              const data = result.data as { trashedKeys: string[] };
-              const trashedKeys = data.trashedKeys || [];
-              dispatch({ type: "TRASH_COMPLETE", trashedKeys });
+              const data = result.data as { trashedKeys: string[] }
+              const trashedKeys = data.trashedKeys || []
+              dispatch({ type: "TRASH_COMPLETE", trashedKeys })
               // Set undo data from the snapshot captured before trash
               if (preTrashSnapshotRef.current && pendingDedupKeysRef.current) {
                 setUndoData({
                   dedupKeys: pendingDedupKeysRef.current,
                   count: pendingDedupKeysRef.current.length,
-                  snapshot: preTrashSnapshotRef.current,
-                });
-                preTrashSnapshotRef.current = null;
-                pendingDedupKeysRef.current = null;
+                  snapshot: preTrashSnapshotRef.current
+                })
+                preTrashSnapshotRef.current = null
+                pendingDedupKeysRef.current = null
               }
             } else {
               dispatch({
                 type: "TRASH_ERROR",
-                error: result.error || "Trash failed",
-              });
+                error: result.error || "Trash failed"
+              })
             }
           } else if (result.command === "restoreItems") {
             if (!result.success) {
               // Optimistic restore already happened in UI; show a non-blocking alert
-              console.error("GPD: Restore failed:", result.error);
+              console.error("GPD: Restore failed:", result.error)
             }
           }
-          break;
+          break
         }
         case "gptkLog":
           if ((message as { level?: string }).level === "error") {
-            dispatch({ type: "GP_TAB_CLOSED" });
+            dispatch({ type: "GP_TAB_CLOSED" })
           }
-          break;
+          break
         case "gptkProgress":
           dispatch({
             type: "SCAN_PROGRESS",
-            payload: message as GptkProgressMessage,
-          });
-          break;
+            payload: message as GptkProgressMessage
+          })
+          break
       }
-    };
+    }
 
-    chrome.runtime.onMessage.addListener(listener);
-    return () => chrome.runtime.onMessage.removeListener(listener);
-  }, []);
+    chrome.runtime.onMessage.addListener(listener)
+    return () => chrome.runtime.onMessage.removeListener(listener)
+  }, [])
 
   // Keep a ref to settings so async callbacks see latest values
-  const settingsRef = useRef(settings);
-  settingsRef.current = settings;
+  const settingsRef = useRef(settings)
+  settingsRef.current = settings
 
   // Run MediaPipe duplicate detection on fetched media items
   const runDuplicateDetection = useCallback(
     async (items: GpdMediaItem[], signal: AbortSignal) => {
-      const logger = scanLoggerRef.current;
-      await logger.start(items.length);
+      const logger = scanLoggerRef.current
+      await logger.start(items.length)
       try {
         const onProgressCallback = (progress: DetectionProgress) => {
           dispatch({
@@ -269,19 +274,19 @@ export default function App() {
               action: "gptkProgress",
               requestId: "",
               itemsProcessed: progress.current,
-              message: `${progress.phase}: ${progress.current}/${progress.total}`,
-            },
-          });
-        };
+              message: `${progress.phase}: ${progress.current}/${progress.total}`
+            }
+          })
+        }
 
         const groups =
           settingsRef.current.scanMode === "smart"
             ? await smartDetectDuplicates(
                 items,
                 settingsRef.current.similarityThreshold,
-                0,
+                1000,
                 onProgressCallback,
-                signal,
+                signal
               )
             : await (async () => {
                 const result = await fullDetectDuplicates(
@@ -289,44 +294,44 @@ export default function App() {
                   settingsRef.current.similarityThreshold,
                   onProgressCallback,
                   signal,
-                  logger,
-                );
-                return result.groups;
-              })();
+                  logger
+                )
+                return result.groups
+              })()
 
-        await logger.finalize("complete", { groupsFound: groups.length });
+        await logger.finalize("complete", { groupsFound: groups.length })
 
-        const mediaItemMap: Record<string, GpdMediaItem> = {};
+        const mediaItemMap: Record<string, GpdMediaItem> = {}
         for (const item of items) {
-          mediaItemMap[item.mediaKey] = item;
+          mediaItemMap[item.mediaKey] = item
         }
 
         dispatch({
           type: "SCAN_COMPLETE",
           mediaItems: mediaItemMap,
-          groups,
-        });
+          groups
+        })
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
-          await logger.finalize("cancelled");
-          dispatch({ type: "SCAN_CANCELLED" });
+          await logger.finalize("cancelled")
+          dispatch({ type: "SCAN_CANCELLED" })
         } else {
-          await logger.finalize("error", { error: String(error) });
+          await logger.finalize("error", { error: String(error) })
           dispatch({
             type: "SCAN_ERROR",
-            error: `Duplicate detection failed: ${error}`,
-          });
+            error: `Duplicate detection failed: ${error}`
+          })
         }
       }
     },
-    [],
-  );
+    []
+  )
 
   // Health check on mount + recover any scan log entry orphaned by a page reload
   useEffect(() => {
-    sendToServiceWorker({ app: APP_ID, action: "healthCheck" });
-    scanLoggerRef.current.recoverStale();
-  }, []);
+    sendToServiceWorker({ app: APP_ID, action: "healthCheck" })
+    scanLoggerRef.current.recoverStale()
+  }, [])
 
   // Load saved settings and results on mount
   useEffect(() => {
@@ -334,84 +339,85 @@ export default function App() {
       ["settings", "scanResults"],
       (result: Partial<StoredState>) => {
         if (result.settings) {
-          setSettings(result.settings);
+          setSettings(result.settings)
         }
-        if (result.scanResults?.totalItems) {
+        if (result.scanResults?.totalItems && result.scanResults.groups?.length > 0) {
           dispatch({
             type: "LOAD_SAVED_RESULTS",
             mediaItems: result.scanResults.mediaItems,
-            groups: result.scanResults.groups ?? [],
-            totalItems: result.scanResults.totalItems,
-          });
+            groups: result.scanResults.groups,
+            totalItems: result.scanResults.totalItems
+          })
         }
-      },
-    );
-  }, []);
+        setStorageChecked(true)
+      }
+    )
+  }, [])
 
   // Persist scan results when they change (after scan or trash)
-  const mediaItems = state.status === "results" ? state.mediaItems : null;
-  const totalItems = state.status === "results" ? state.totalItems : 0;
+  const mediaItems = state.status === "results" ? state.mediaItems : null
+  const totalItems = state.status === "results" ? state.totalItems : 0
   useEffect(() => {
-    if (!mediaItems) return;
+    if (!mediaItems) return
     if (groups.length > 0) {
       const newestCreationTimestamp = Object.values(mediaItems).reduce(
         (max, item) => Math.max(max, item.creationTimestamp ?? 0),
-        0,
-      );
+        0
+      )
       chrome.storage.local.set({
         scanResults: {
           mediaItems,
           groups,
           scanDate: Date.now(),
           totalItems,
-          newestCreationTimestamp,
-        },
-      });
+          newestCreationTimestamp
+        }
+      })
     } else {
       // All duplicates removed — clear saved results so next open starts fresh
-      chrome.storage.local.remove("scanResults");
+      chrome.storage.local.remove("scanResults")
     }
-  }, [groups, mediaItems, totalItems]);
+  }, [groups, mediaItems, totalItems])
 
   // Save settings on change
   useEffect(() => {
-    chrome.storage.local.set({ settings });
-  }, [settings]);
+    chrome.storage.local.set({ settings })
+  }, [settings])
 
   const handleStartScan = useCallback(async () => {
     // Cancel any in-progress scan
-    scanAbortRef.current?.abort();
-    scanAbortRef.current = new AbortController();
+    scanAbortRef.current?.abort()
+    scanAbortRef.current = new AbortController()
 
-    const requestId = generateRequestId();
-    const hasGptk = state.status === "connected" ? state.hasGptk : true;
+    const requestId = generateRequestId()
+    const hasGptk = state.status === "connected" ? state.hasGptk : true
     const accountEmail =
       state.status === "connected" || state.status === "results"
         ? state.accountEmail
-        : undefined;
-    dispatch({ type: "SCAN_STARTED", requestId, hasGptk, accountEmail });
+        : undefined
+    dispatch({ type: "SCAN_STARTED", requestId, hasGptk, accountEmail })
 
     // Load cached media items for incremental fetch. On a repeat scan we only
     // fetch items newer than the most-recently-seen upload timestamp.
-    cachedMediaItemsRef.current = null;
-    let sinceTimestamp: number | undefined;
+    cachedMediaItemsRef.current = null
+    let sinceTimestamp: number | undefined
     try {
       const stored = (await chrome.storage.local.get(
-        "scanResults",
-      )) as Partial<StoredState>;
-      const prev = stored.scanResults;
+        "scanResults"
+      )) as Partial<StoredState>
+      const prev = stored.scanResults
       if (prev?.mediaItems && Object.keys(prev.mediaItems).length > 0) {
-        cachedMediaItemsRef.current = prev.mediaItems;
+        cachedMediaItemsRef.current = prev.mediaItems
         // Compute watermark if not stored (migration: first run after this deploy)
         sinceTimestamp =
           prev.newestCreationTimestamp ??
           Object.values(prev.mediaItems).reduce(
             (max, item) => Math.max(max, item.creationTimestamp ?? 0),
-            0,
-          );
+            0
+          )
         console.log(
-          `[GPD] media items cache: ${Object.keys(prev.mediaItems).length} items, fetching since ${new Date(sinceTimestamp).toISOString()}`,
-        );
+          `[GPD] media items cache: ${Object.keys(prev.mediaItems).length} items, fetching since ${new Date(sinceTimestamp).toISOString()}`
+        )
       }
     } catch {
       // Cache unavailable — do full fetch
@@ -424,118 +430,118 @@ export default function App() {
       requestId,
       args: {
         dateRange: settings.dateRange,
-        sinceTimestamp,
-      },
-    });
-  }, [settings]);
+        sinceTimestamp
+      }
+    })
+  }, [settings])
 
   const handleTrash = useCallback(() => {
-    if (state.status !== "results") return;
+    if (state.status !== "results") return
 
-    const dedupKeys: string[] = [];
-    const mediaKeysToTrash: string[] = [];
+    const dedupKeys: string[] = []
+    const mediaKeysToTrash: string[] = []
     for (const group of state.groups) {
-      if (!selectedGroupIds.has(group.id)) continue;
-      const keptSet = getKept(group);
+      if (!selectedGroupIds.has(group.id)) continue
+      const keptSet = getKept(group)
       for (const key of group.mediaKeys) {
-        if (keptSet.has(key)) continue;
-        const item = state.mediaItems[key];
+        if (keptSet.has(key)) continue
+        const item = state.mediaItems[key]
         if (item?.dedupKey) {
-          dedupKeys.push(item.dedupKey);
-          mediaKeysToTrash.push(key);
+          dedupKeys.push(item.dedupKey)
+          mediaKeysToTrash.push(key)
         }
       }
     }
 
-    if (dedupKeys.length === 0) return;
-    setTrashConfirm({ dedupKeys, mediaKeysToTrash });
-  }, [state, selectedGroupIds, getKept]);
+    if (dedupKeys.length === 0) return
+    setTrashConfirm({ dedupKeys, mediaKeysToTrash })
+  }, [state, selectedGroupIds, getKept])
 
   const handleTrashConfirmed = useCallback(() => {
-    if (!trashConfirm || state.status !== "results") return;
-    const { dedupKeys, mediaKeysToTrash } = trashConfirm;
-    setTrashConfirm(null);
+    if (!trashConfirm || state.status !== "results") return
+    const { dedupKeys, mediaKeysToTrash } = trashConfirm
+    setTrashConfirm(null)
 
-    const requestId = generateRequestId();
+    const requestId = generateRequestId()
 
     // Capture snapshot for undo
     preTrashSnapshotRef.current = {
       mediaItems: state.mediaItems,
       groups: state.groups,
-      totalItems: state.totalItems,
-    };
-    pendingDedupKeysRef.current = dedupKeys;
+      totalItems: state.totalItems
+    }
+    pendingDedupKeysRef.current = dedupKeys
 
     dispatch({
       type: "TRASH_STARTED",
       totalToTrash: dedupKeys.length,
       mediaItems: state.mediaItems,
       groups: state.groups,
-      totalItems: state.totalItems,
-    });
+      totalItems: state.totalItems
+    })
 
     sendToServiceWorker({
       app: APP_ID,
       action: "gptkCommand",
       command: "trashItems",
       requestId,
-      args: { dedupKeys, mediaKeysToTrash },
-    });
-  }, [trashConfirm, state]);
+      args: { dedupKeys, mediaKeysToTrash }
+    })
+  }, [trashConfirm, state])
 
   const handleCancelScan = useCallback(() => {
-    scanAbortRef.current?.abort();
-    dispatch({ type: "SCAN_CANCELLED" });
-  }, []);
+    scanAbortRef.current?.abort()
+    dispatch({ type: "SCAN_CANCELLED" })
+  }, [])
 
-  const handleRetry = useCallback(() => {
-    dispatch({ type: "RESET" });
-    sendToServiceWorker({ app: APP_ID, action: "healthCheck" });
-  }, []);
+  const handleReset = useCallback(() => {
+    dispatch({ type: "RESET" })
+    sendToServiceWorker({ app: APP_ID, action: "healthCheck" })
+  }, [])
 
   const handleUndo = useCallback(() => {
-    if (!undoData) return;
+    if (!undoData) return
     // Optimistically restore the UI to the pre-trash state
     dispatch({
       type: "RESTORE_SNAPSHOT",
       mediaItems: undoData.snapshot.mediaItems,
       groups: undoData.snapshot.groups,
-      totalItems: undoData.snapshot.totalItems,
-    });
+      totalItems: undoData.snapshot.totalItems
+    })
     // Call GPTK to restore from trash
     sendToServiceWorker({
       app: APP_ID,
       action: "gptkCommand",
       command: "restoreItems",
       requestId: generateRequestId(),
-      args: { dedupKeys: undoData.dedupKeys },
-    });
-    setUndoData(null);
-  }, [undoData]);
+      args: { dedupKeys: undoData.dedupKeys }
+    })
+    setUndoData(null)
+  }, [undoData])
 
   const handleUndoClose = useCallback(() => {
-    setUndoData(null);
-  }, []);
+    setUndoData(null)
+  }, [])
 
   // Fire confetti when trash completes
   useEffect(() => {
-    if (!undoData) return;
+    if (!undoData) return
     confetti({
       particleCount: 200,
       spread: 100,
-      origin: { y: 0.7 },
-    });
-  }, [undoData]);
+      origin: { y: 0.7 }
+    })
+  }, [undoData])
 
   // Compute duplicate count for ActionBar
   const duplicateCount =
     state.status === "results"
       ? groups.reduce((sum, group) => {
-          if (!selectedGroupIds.has(group.id)) return sum;
-          const keptSet = getKept(group);
-          return sum + group.mediaKeys.filter((k) => !keptSet.has(k)).length;
+          if (!selectedGroupIds.has(group.id)) return sum
+          const keptSet = getKept(group)
+          return sum + group.mediaKeys.filter((k) => !keptSet.has(k)).length
         }, 0)
-      : 0;
+      : 0
 
   return (
     <ThemeProvider theme={theme}>
@@ -558,8 +564,7 @@ export default function App() {
       {/* Main content */}
       <Box
         component="main"
-        sx={{ maxWidth: 1200, mx: "auto", px: 3, minHeight: "60vh" }}
-      >
+        sx={{ maxWidth: 1200, mx: "auto", px: 3, minHeight: "60vh" }}>
         {state.status === "connecting" && (
           <Box sx={{ display: "flex", justifyContent: "center", pt: 10 }}>
             <CircularProgress />
@@ -573,9 +578,8 @@ export default function App() {
               flexDirection: "column",
               alignItems: "center",
               pt: 8,
-              gap: 2,
-            }}
-          >
+              gap: 2
+            }}>
             <Alert severity="error" sx={{ maxWidth: 480, width: "100%" }}>
               {state.error}
             </Alert>
@@ -584,11 +588,10 @@ export default function App() {
                 variant="contained"
                 href="https://photos.google.com/login"
                 target="_blank"
-                rel="noopener noreferrer"
-              >
+                rel="noopener noreferrer">
                 Open Google Photos
               </Button>
-              <Button variant="outlined" onClick={handleRetry}>
+              <Button variant="outlined" onClick={handleReset}>
                 Retry Connection
               </Button>
             </Box>
@@ -617,20 +620,19 @@ export default function App() {
           />
         )}
 
-        {state.status === "results" && groups.length === 0 && (
+        {state.status === "results" && groups.length === 0 && storageChecked && (
           <Box
             sx={{
               display: "flex",
               flexDirection: "column",
               alignItems: "center",
               pt: 8,
-              gap: 2,
-            }}
-          >
+              gap: 2
+            }}>
             <Typography variant="h6" color="text.secondary">
               No duplicates found in your library.
             </Typography>
-            <Button variant="contained" onClick={handleRetry}>
+            <Button variant="contained" onClick={handleReset}>
               Back to Scan
             </Button>
           </Box>
@@ -645,7 +647,7 @@ export default function App() {
               onSelectAll={handleSelectAll}
               onDeselectAll={handleDeselectAll}
               onTrash={handleTrash}
-              onRescan={handleStartScan}
+              onRescan={handleReset}
             />
             <DuplicateGroups
               groups={state.groups}
@@ -665,9 +667,8 @@ export default function App() {
               flexDirection: "column",
               alignItems: "center",
               pt: 8,
-              gap: 2,
-            }}
-          >
+              gap: 2
+            }}>
             <CircularProgress size={28} />
             <Typography variant="body2" color="text.secondary">
               Moving items to trash…
@@ -691,8 +692,7 @@ export default function App() {
           <Button
             onClick={handleTrashConfirmed}
             variant="contained"
-            color="error"
-          >
+            color="error">
             Move to Trash
           </Button>
         </DialogActions>
@@ -721,5 +721,5 @@ export default function App() {
         }
       />
     </ThemeProvider>
-  );
+  )
 }

--- a/tests/lib/duplicate-detector.test.ts
+++ b/tests/lib/duplicate-detector.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest"
-import { communityDetection, matMul, topK } from "../../lib/duplicate-detector"
+import { communityDetection, matMul, topK, groupByTimestamp, withinGroupDuplicates } from "../../lib/duplicate-detector"
+import type { GpdMediaItem } from "../../lib/types"
 
 // ============================================================
 // Helpers
@@ -200,5 +201,217 @@ describe("communityDetection", () => {
     const allIndices = groups.flat()
     const uniqueIndices = new Set(allIndices)
     expect(allIndices.length).toBe(uniqueIndices.size)
+  })
+})
+
+// ============================================================
+// Helper: build a minimal GpdMediaItem for testing
+// ============================================================
+
+function makeItem(
+  mediaKey: string,
+  timestamp: number,
+  creationTimestamp = 0,
+): GpdMediaItem {
+  return {
+    mediaKey,
+    dedupKey: mediaKey,
+    thumb: `https://example.com/${mediaKey}`,
+    timestamp,
+    creationTimestamp,
+  }
+}
+
+// ============================================================
+// groupByTimestamp
+// ============================================================
+
+describe("groupByTimestamp", () => {
+  it("groups two items with the same timestamp", () => {
+    const a = makeItem("a", 1000)
+    const b = makeItem("b", 1000)
+    const result = groupByTimestamp([a, b])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toContain(a)
+    expect(result[0]).toContain(b)
+  })
+
+  it("does not group items with different timestamps", () => {
+    const a = makeItem("a", 1000)
+    const b = makeItem("b", 2000)
+    const result = groupByTimestamp([a, b])
+    expect(result).toHaveLength(0)
+  })
+
+  it("returns empty when all timestamps are unique", () => {
+    const items = [makeItem("a", 1), makeItem("b", 2), makeItem("c", 3)]
+    expect(groupByTimestamp(items)).toHaveLength(0)
+  })
+
+  it("handles three-way same-timestamp group", () => {
+    const items = [makeItem("a", 5000), makeItem("b", 5000), makeItem("c", 5000)]
+    const result = groupByTimestamp(items)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toHaveLength(3)
+  })
+
+  it("separates two independent pairs into two buckets", () => {
+    const items = [
+      makeItem("a", 1000),
+      makeItem("b", 1000),
+      makeItem("c", 2000),
+      makeItem("d", 2000),
+    ]
+    const result = groupByTimestamp(items)
+    expect(result).toHaveLength(2)
+    for (const bucket of result) expect(bucket).toHaveLength(2)
+  })
+
+  it("excludes singleton buckets (only groups of ≥2)", () => {
+    const items = [makeItem("a", 1000), makeItem("b", 2000), makeItem("c", 2000)]
+    const result = groupByTimestamp(items)
+    expect(result).toHaveLength(1)
+    expect(result[0].map((i) => i.mediaKey)).toEqual(expect.arrayContaining(["b", "c"]))
+  })
+
+  it("windowMs=1000 groups items within the same second", () => {
+    const a = makeItem("a", 1100)
+    const b = makeItem("b", 1800)
+    // Both floor to 1000 with windowMs=1000
+    const result = groupByTimestamp([a, b], 1000)
+    expect(result).toHaveLength(1)
+  })
+
+  it("windowMs=1000 keeps items in different seconds separate", () => {
+    const a = makeItem("a", 999)
+    const b = makeItem("b", 1001)
+    // a floors to 0, b floors to 1000
+    const result = groupByTimestamp([a, b], 1000)
+    expect(result).toHaveLength(0)
+  })
+})
+
+// ============================================================
+// withinGroupDuplicates
+// ============================================================
+
+describe("withinGroupDuplicates", () => {
+  const DIM = 64
+  const THRESHOLD = 0.99
+
+  function makeEmbeddingMap(
+    items: GpdMediaItem[],
+    embeddings: Float32Array[],
+  ): Map<string, Float32Array> {
+    const map = new Map<string, Float32Array>()
+    for (let i = 0; i < items.length; i++) map.set(items[i].mediaKey, embeddings[i])
+    return map
+  }
+
+  it("groups two near-identical embeddings (above threshold)", () => {
+    const base = l2normalize(new Float32Array(DIM).map(() => Math.random()))
+    const a = makeItem("a", 1000)
+    const b = makeItem("b", 1000)
+    const embA = addNoise(new Float32Array(base), 0.001)
+    const embB = addNoise(new Float32Array(base), 0.001)
+    const map = makeEmbeddingMap([a, b], [embA, embB])
+    const groups = withinGroupDuplicates([a, b], map, THRESHOLD, 0)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].mediaKeys).toHaveLength(2)
+  })
+
+  it("does not group embeddings below threshold", () => {
+    const a = makeItem("a", 1000)
+    const b = makeItem("b", 1000)
+    const embA = unitVector(DIM, 0)
+    const embB = unitVector(DIM, 1)
+    const map = makeEmbeddingMap([a, b], [embA, embB])
+    const groups = withinGroupDuplicates([a, b], map, THRESHOLD, 0)
+    expect(groups).toHaveLength(0)
+  })
+
+  it("handles transitive grouping: A~B and B~C → single group {A,B,C}", () => {
+    const base = l2normalize(new Float32Array(DIM).map(() => Math.random()))
+    const items = [makeItem("a", 1000), makeItem("b", 1000), makeItem("c", 1000)]
+    const embs = items.map(() => addNoise(new Float32Array(base), 0.001))
+    const map = makeEmbeddingMap(items, embs)
+    const groups = withinGroupDuplicates(items, map, THRESHOLD, 0)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].mediaKeys).toHaveLength(3)
+  })
+
+  it("two independent similar pairs → two separate groups", () => {
+    const base1 = l2normalize(new Float32Array(DIM).map(() => Math.random()))
+    const base2 = unitVector(DIM, 0)
+    const items = [
+      makeItem("a", 1000),
+      makeItem("b", 1000),
+      makeItem("c", 1000),
+      makeItem("d", 1000),
+    ]
+    const embs = [
+      addNoise(new Float32Array(base1), 0.001),
+      addNoise(new Float32Array(base1), 0.001),
+      addNoise(new Float32Array(base2), 0.001),
+      addNoise(new Float32Array(base2), 0.001),
+    ]
+    const map = makeEmbeddingMap(items, embs)
+    const groups = withinGroupDuplicates(items, map, THRESHOLD, 0)
+    expect(groups).toHaveLength(2)
+    for (const g of groups) expect(g.mediaKeys).toHaveLength(2)
+  })
+
+  it("skips items with no entry in embeddingMap (thumbnail/embed failed)", () => {
+    const base = l2normalize(new Float32Array(DIM).map(() => Math.random()))
+    const a = makeItem("a", 1000)
+    const b = makeItem("b", 1000)
+    const missing = makeItem("missing", 1000)
+    const map = makeEmbeddingMap([a, b], [
+      addNoise(new Float32Array(base), 0.001),
+      addNoise(new Float32Array(base), 0.001),
+    ])
+    // missing has no entry in map
+    const groups = withinGroupDuplicates([a, b, missing], map, THRESHOLD, 0)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].mediaKeys).not.toContain("missing")
+  })
+
+  it("sets originalMediaKey to item with earliest creationTimestamp", () => {
+    const base = l2normalize(new Float32Array(DIM).map(() => Math.random()))
+    const older = makeItem("older", 1000, 100)
+    const newer = makeItem("newer", 1000, 200)
+    const embs = [
+      addNoise(new Float32Array(base), 0.001),
+      addNoise(new Float32Array(base), 0.001),
+    ]
+    const map = makeEmbeddingMap([older, newer], embs)
+    const groups = withinGroupDuplicates([newer, older], map, THRESHOLD, 0)
+    expect(groups[0].originalMediaKey).toBe("older")
+  })
+
+  it("each item appears in at most one group (no double-count)", () => {
+    const base = l2normalize(new Float32Array(DIM).map(() => Math.random()))
+    const items = Array.from({ length: 5 }, (_, i) => makeItem(`item${i}`, 1000))
+    const embs = items.map(() => addNoise(new Float32Array(base), 0.001))
+    const map = makeEmbeddingMap(items, embs)
+    const groups = withinGroupDuplicates(items, map, THRESHOLD, 0)
+    const allKeys = groups.flatMap((g) => g.mediaKeys)
+    expect(allKeys.length).toBe(new Set(allKeys).size)
+  })
+
+  it("groups are returned largest-first", () => {
+    const base1 = l2normalize(new Float32Array(DIM).map(() => Math.random()))
+    const base2 = unitVector(DIM, 0)
+    const trio = Array.from({ length: 3 }, (_, i) => makeItem(`trio${i}`, 1000))
+    const pair = Array.from({ length: 2 }, (_, i) => makeItem(`pair${i}`, 1000))
+    const embs = [
+      ...trio.map(() => addNoise(new Float32Array(base1), 0.001)),
+      ...pair.map(() => addNoise(new Float32Array(base2), 0.001)),
+    ]
+    const map = makeEmbeddingMap([...trio, ...pair], embs)
+    const groups = withinGroupDuplicates([...trio, ...pair], map, THRESHOLD, 0)
+    if (groups.length >= 2) {
+      expect(groups[0].mediaKeys.length).toBeGreaterThanOrEqual(groups[1].mediaKeys.length)
+    }
   })
 })

--- a/workers/embedder.worker.ts
+++ b/workers/embedder.worker.ts
@@ -169,50 +169,139 @@ self.addEventListener("message", async (event: MessageEvent) => {
 
 // ============================================================
 // Community detection helpers (inlined — no browser/extension dependencies)
-// Kept in sync with lib/duplicate-detector.ts
 // ============================================================
 
+/**
+ * Full pairwise community detection.
+ *
+ * For each item, finds all other items whose cosine similarity exceeds the
+ * threshold (via batched matrix multiplication). Extracts the largest
+ * non-overlapping communities.
+ *
+ * This is the correct algorithm for the "full" scan — it catches all
+ * duplicate pairs regardless of timestamp order, unlike the old adjacent-only
+ * linear scan that missed non-temporally-adjacent duplicates.
+ */
 async function workerCommunityDetection(
   embeddings: Float32Array[],
   threshold: number,
-  timestamps?: number[],
+  _timestamps?: number[],
   onProgress?: (current: number, total: number) => void,
 ): Promise<number[][]> {
   const n = embeddings.length;
   const dim = embeddings[0].length;
+  const batchSize = 128;
+  const minCommunitySize = 2;
+  const extractedCommunities: number[][] = [];
+  let sortMaxSize = Math.min(Math.max(2 * minCommunitySize, 50), n);
 
-  // Sort by timestamp so nearby photos are adjacent
-  const order = Array.from({ length: n }, (_, i) => i);
-  if (timestamps) {
-    order.sort((a, b) => (timestamps[a] ?? 0) - (timestamps[b] ?? 0));
-  }
+  for (let startIdx = 0; startIdx < n; startIdx += batchSize) {
+    const endIdx = Math.min(startIdx + batchSize, n);
+    const batchLen = endIdx - startIdx;
 
-  const sorted: Float32Array[] = order.map((i) => embeddings[i]);
-  const groups: number[][] = [];
-  let currentGroup: number[] = [order[0]];
+    // Compute cosine similarity: batch x all embeddings
+    // Embeddings are L2-normalized so cos_sim = dot product
+    const cosScores = matMul(embeddings, startIdx, endIdx, embeddings, 0, n, dim);
 
-  for (let i = 0; i < n - 1; i++) {
-    // Cosine similarity = dot product (embeddings are L2-normalized)
-    const a = sorted[i];
-    const b = sorted[i + 1];
-    let dot = 0;
-    for (let k = 0; k < dim; k++) dot += a[k] * b[k];
+    for (let i = 0; i < batchLen; i++) {
+      const row = cosScores.subarray(i * n, (i + 1) * n);
 
-    if (dot >= threshold) {
-      currentGroup.push(order[i + 1]);
-    } else {
-      if (currentGroup.length >= 2) groups.push(currentGroup);
-      currentGroup = [order[i + 1]];
+      // Quick check: are there at least minCommunitySize items above threshold?
+      const topKMin = topK(row, minCommunitySize);
+      if (topKMin.values[topKMin.values.length - 1] < threshold) continue;
+
+      // Find all items above threshold
+      let topKResult = topK(row, sortMaxSize);
+
+      // Expand search window if needed
+      while (
+        topKResult.values[topKResult.values.length - 1] > threshold &&
+        sortMaxSize < n
+      ) {
+        sortMaxSize = Math.min(2 * sortMaxSize, n);
+        topKResult = topK(row, sortMaxSize);
+      }
+
+      const cluster: number[] = [];
+      for (let j = 0; j < topKResult.values.length; j++) {
+        if (topKResult.values[j] < threshold) break;
+        cluster.push(topKResult.indices[j]);
+      }
+
+      if (cluster.length >= minCommunitySize) {
+        extractedCommunities.push(cluster);
+      }
     }
 
-    if (i % 500 === 0) {
-      onProgress?.(i + 1, n);
-      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    onProgress?.(endIdx, n);
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+
+  // Sort communities by size (largest first)
+  extractedCommunities.sort((a, b) => b.length - a.length);
+
+  // Remove overlapping communities (greedy: assign each item to largest community first)
+  const uniqueCommunities: number[][] = [];
+  const assignedIds = new Set<number>();
+
+  for (const community of extractedCommunities) {
+    const nonOverlapping = community
+      .slice()
+      .sort((a, b) => a - b)
+      .filter((idx) => !assignedIds.has(idx));
+
+    if (nonOverlapping.length >= minCommunitySize) {
+      uniqueCommunities.push(nonOverlapping);
+      for (const idx of nonOverlapping) assignedIds.add(idx);
     }
   }
 
-  if (currentGroup.length >= 2) groups.push(currentGroup);
+  uniqueCommunities.sort((a, b) => b.length - a.length);
+  return uniqueCommunities;
+}
 
-  groups.sort((a, b) => b.length - a.length);
-  return groups;
+function matMul(
+  A: Float32Array[],
+  startA: number,
+  endA: number,
+  B: Float32Array[],
+  startB: number,
+  endB: number,
+  dim: number,
+): Float32Array {
+  const rowsA = endA - startA;
+  const rowsB = endB - startB;
+  const result = new Float32Array(rowsA * rowsB);
+
+  for (let i = 0; i < rowsA; i++) {
+    const aRow = A[startA + i];
+    for (let j = 0; j < rowsB; j++) {
+      const bRow = B[startB + j];
+      let dot = 0;
+      for (let k = 0; k < dim; k++) dot += aRow[k] * bRow[k];
+      result[i * rowsB + j] = dot;
+    }
+  }
+
+  return result;
+}
+
+function topK(
+  arr: Float32Array,
+  k: number,
+): { values: number[]; indices: number[] } {
+  k = Math.min(k, arr.length);
+
+  const indexed: Array<{ val: number; idx: number }> = [];
+  for (let i = 0; i < arr.length; i++) indexed.push({ val: arr[i], idx: i });
+  indexed.sort((a, b) => b.val - a.val);
+
+  const values: number[] = [];
+  const indices: number[] = [];
+  for (let i = 0; i < k; i++) {
+    values.push(indexed[i].val);
+    indices.push(indexed[i].idx);
+  }
+
+  return { values, indices };
 }

--- a/workers/embedder.worker.ts
+++ b/workers/embedder.worker.ts
@@ -8,6 +8,7 @@
 //   { type: "init", data: { wasmLoaderUrl, wasmBinaryUrl, modelBuffer: ArrayBuffer } }
 //   { type: "embed", data: { items: Array<{ localIdx: number, blob: Blob }> } }
 //   { type: "detect", data: { flatEmbeddings: Float32Array, n: number, dim: number, threshold: number } }
+//   { type: "detectSmart", data: { flatEmbeddings: Float32Array, n: number, dim: number, threshold: number, buckets: number[][] } }
 //
 // Message protocol (worker → main):
 //   { type: "ready" }
@@ -112,6 +113,57 @@ self.addEventListener("message", async (event: MessageEvent) => {
       },
     );
     self.postMessage({ type: "detectionResults", groups });
+  }
+
+  if (type === "detectSmart") {
+    const { flatEmbeddings, n, dim, threshold, buckets } = data as {
+      flatEmbeddings: Float32Array;
+      n: number;
+      dim: number;
+      threshold: number;
+      buckets: number[][];
+    };
+
+    // Unpack flat buffer into row views (zero-copy)
+    const embeddings: Float32Array[] = [];
+    for (let i = 0; i < n; i++)
+      embeddings.push(flatEmbeddings.subarray(i * dim, (i + 1) * dim));
+
+    const allGroups: number[][] = [];
+    for (let bi = 0; bi < buckets.length; bi++) {
+      const bucket = buckets[bi];
+      // Union-Find over bucket indices
+      const parent = bucket.map((_, j) => j);
+      const find = (x: number): number =>
+        parent[x] === x ? x : (parent[x] = find(parent[x]));
+      const union = (a: number, b: number) => {
+        parent[find(a)] = find(b);
+      };
+
+      for (let i = 0; i < bucket.length; i++) {
+        for (let j = i + 1; j < bucket.length; j++) {
+          const a = embeddings[bucket[i]];
+          const b = embeddings[bucket[j]];
+          let dot = 0;
+          for (let k = 0; k < dim; k++) dot += a[k] * b[k];
+          if (dot >= threshold) union(i, j);
+        }
+      }
+
+      const components = new Map<number, number[]>();
+      for (let i = 0; i < bucket.length; i++) {
+        const root = find(i);
+        if (!components.has(root)) components.set(root, []);
+        components.get(root)!.push(bucket[i]); // original embedding indices
+      }
+      for (const [, members] of components)
+        if (members.length >= 2) allGroups.push(members);
+
+      if (bi % 100 === 0)
+        self.postMessage({ type: "detectionProgress", current: bi + 1, total: buckets.length });
+    }
+
+    self.postMessage({ type: "detectionResults", groups: allGroups });
   }
 });
 


### PR DESCRIPTION
## Summary

### Major Updates

#### Scan Modes

- **Smart scan mode** (new default): buckets photos by EXIF timestamp, computes embeddings only for the matched subset, and runs pairwise union-find per bucket in the worker — making detection fast regardless of library size vs hours for the O(n²) full scan. Inspired by @white-hat's #104.
  - ❗ On my personal library of 50k photos, this found **98% of duplicate groups in 2% of the time (50x faster)** 🎉 
- **Full scan mode** preserved in a collapsed _More options_ accordion in `ScanConfig`; community detection algorithm restored to true pairwise O(n²) (unintentionally replaced with adjacent-pair linear scan merging above PR)

### Minor updates:

  - **Progress bar fix**: stale GPTK batch-fetch messages no longer overwrite `itemsProcessed` once the scan has advanced past the fetching phase
  - **Logging**: ScanLogger (`lib/scan-log.ts`): incrementally persists an active scan entry to `chrome.storage.local` after each phase. StabilityTracker: fires a stable-estimate log once 3 consecutive projected-duration samples for a phase are within 5% of each other. Scan start log  logs `mode` and `similarityThreshold` at the beginning of each scan run.

## Test plan

- [x] Open extension on a Google Photos library; verify smart scan completes quickly and finds burst/near-duplicate groups
- [x] Switch to full scan in More options; verify it runs the full O(n²) pipeline and finds the same duplicates as previous `main` branch
- [x] Verify progress bar never jumps backwards during a full scan
- [x] Check `chrome.storage.local.get("scanLogs")` in the service worker console after a scan — should contain a complete entry with per-phase timing
- [x] Reload the page mid-scan; verify the log entry is marked `killed_by_reload`
- [x] Check DevTools console for `[GPD] starting scan: mode=..., threshold=...` on scan start