### PR TITLE
Fix HTTP 504 on large trash/restore operations

### DIFF
--- a/lib/app-reducer.ts
+++ b/lib/app-reducer.ts
@@ -40,6 +40,7 @@ export type AppState =
       groups: DuplicateGroup[]
       totalItems: number
       totalToTrash: number
+      trashedSoFar: number
       accountEmail?: string
     }
 
@@ -62,6 +63,7 @@ export type AppAction =
       groups: DuplicateGroup[]
       totalItems: number
     }
+  | { type: "TRASH_PROGRESS"; trashedSoFar: number }
   | { type: "TRASH_COMPLETE"; trashedKeys: string[] }
   | { type: "TRASH_ERROR"; error: string }
   | {
@@ -164,8 +166,13 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         groups: action.groups,
         totalItems: action.totalItems,
         totalToTrash: action.totalToTrash,
+        trashedSoFar: 0,
         accountEmail: "accountEmail" in state ? state.accountEmail : undefined,
       }
+
+    case "TRASH_PROGRESS":
+      if (state.status !== "trashing") return state
+      return { ...state, trashedSoFar: action.trashedSoFar }
 
     case "TRASH_COMPLETE": {
       if (state.status !== "trashing") return state

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -118,6 +118,8 @@ export interface GptkProgressMessage extends BaseMessage {
   requestId: string;
   itemsProcessed: number;
   message?: string;
+  /** Set by batch operations (e.g. "trashItems") so the app can route progress correctly. */
+  command?: string;
 }
 
 export interface GptkLogMessage extends BaseMessage {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "test:integration": "playwright test --config playwright.config.ts",
     "test:e2e": "playwright test --config playwright.e2e.config.ts",
     "sync:scripts": "cp scripts/google-photos-commands.js build/chrome-mv3-dev/scripts/ 2>/dev/null || true",
-    "dev": "npm run build:gptk && npm run copy:wasm && plasmo dev",
+    "dev": "npm run build:gptk && npm run copy:wasm && npm run build:worker && plasmo dev",
+    "prebuild": "npm run build:gptk && npm run copy:wasm && npm run build:worker && npm run sync:scripts",
     "build": "npm run build:gptk && npm run copy:wasm && npm run build:worker && plasmo build && cp -r build/chrome-mv3-prod/. build/chrome-mv3-dev/",
-    "package": "npm run build:gptk && npm run copy:wasm && plasmo build && plasmo package",
+    "package": "npm run build && plasmo package",
     "release": "bash tools/release.sh"
   },
   "dependencies": {

--- a/scripts/google-photos-commands.js
+++ b/scripts/google-photos-commands.js
@@ -5,7 +5,11 @@
 // Communication with the extension happens via window.postMessage.
 // The bridge content script (google-photos-bridge.ts) relays these to chrome.runtime.
 
-const GPD_APP_ID = "GPD";
+const GPD_APP_ID = "GPD"
+
+// Number of items per API request for batch operations (trash, restore).
+// Matches GPTK's default operationSize. Large single requests cause HTTP 504.
+const BATCH_SIZE = 250
 
 function postResult(command, requestId, data) {
   window.postMessage({
@@ -14,8 +18,8 @@ function postResult(command, requestId, data) {
     command,
     requestId,
     success: true,
-    data,
-  });
+    data
+  })
 }
 
 function postError(command, requestId, error) {
@@ -25,18 +29,28 @@ function postError(command, requestId, error) {
     command,
     requestId,
     success: false,
-    error: String(error),
-  });
+    error: String(error)
+  })
 }
 
-function postProgress(requestId, itemsProcessed, message) {
+// command is optional; when provided, the app can route progress to the right handler.
+function postProgress(requestId, itemsProcessed, message, command) {
   window.postMessage({
     app: GPD_APP_ID,
     action: "gptkProgress",
     requestId,
     itemsProcessed,
     message,
-  });
+    ...(command !== undefined ? { command } : {})
+  })
+}
+
+function chunkArray(arr, size) {
+  const chunks = []
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size))
+  }
+  return chunks
 }
 
 // ============================================================
@@ -45,30 +59,30 @@ function postProgress(requestId, itemsProcessed, message) {
 // ============================================================
 
 async function getAllMediaItems(requestId, args) {
-  const gptkApi = window.gptkApi;
+  const gptkApi = window.gptkApi
   if (!gptkApi) {
     postError(
       "getAllMediaItems",
       requestId,
-      "GPTK API not available. Reload the Google Photos page.",
-    );
-    return;
+      "GPTK API not available. Reload the Google Photos page."
+    )
+    return
   }
 
   // sinceTimestamp: stop paginating once we reach items already in the cache
   const sinceTimestamp =
-    args && args.sinceTimestamp ? args.sinceTimestamp : null;
+    args && args.sinceTimestamp ? args.sinceTimestamp : null
 
   try {
-    let nextPageId = null;
-    const mediaItems = [];
-    let reachedCache = false;
+    let nextPageId = null
+    const mediaItems = []
+    let reachedCache = false
 
     do {
-      const page = await gptkApi.getItemsByUploadedDate(nextPageId);
+      const page = await gptkApi.getItemsByUploadedDate(nextPageId)
       if (!page) {
-        console.warn("GPD: Empty page response, stopping pagination");
-        break;
+        console.warn("GPD: Empty page response, stopping pagination")
+        break
       }
       if (page.items && page.items.length > 0) {
         for (const item of page.items) {
@@ -77,8 +91,8 @@ async function getAllMediaItems(requestId, args) {
             sinceTimestamp !== null &&
             item.creationTimestamp <= sinceTimestamp
           ) {
-            reachedCache = true;
-            break;
+            reachedCache = true
+            break
           }
           mediaItems.push({
             mediaKey: item.mediaKey,
@@ -91,24 +105,24 @@ async function getAllMediaItems(requestId, args) {
             duration: item.duration,
             isOwned: item.isOwned,
             fileName: item.descriptionShort || null,
-            productUrl: "https://photos.google.com/photo/" + item.mediaKey,
-          });
+            productUrl: "https://photos.google.com/photo/" + item.mediaKey
+          })
         }
       }
-      nextPageId = page.nextPageId || null;
+      nextPageId = page.nextPageId || null
 
       postProgress(
         requestId,
         mediaItems.length,
-        `Fetched ${mediaItems.length} items`,
-      );
+        `Fetched ${mediaItems.length} items`
+      )
 
-      if (reachedCache) break;
-    } while (nextPageId);
+      if (reachedCache) break
+    } while (nextPageId)
 
-    postResult("getAllMediaItems", requestId, mediaItems);
+    postResult("getAllMediaItems", requestId, mediaItems)
   } catch (error) {
-    postError("getAllMediaItems", requestId, error);
+    postError("getAllMediaItems", requestId, error)
   }
 }
 
@@ -121,32 +135,50 @@ async function trashItems(requestId, args) {
   // Call api.moveItemsToTrash directly instead of gptkApiUtils.moveToTrash,
   // because the latter goes through executeWithConcurrency which checks
   // gptkCore.isProcessRunning (always false when called from extension).
-  const api = window.gptkApiUtils?.api;
+  const api = window.gptkApiUtils?.api
   if (!api) {
     postError(
       "trashItems",
       requestId,
-      "GPTK API not available. Reload the Google Photos page.",
-    );
-    return;
+      "GPTK API not available. Reload the Google Photos page."
+    )
+    return
   }
 
   try {
-    const dedupKeys = args.dedupKeys;
-    const mediaKeysToTrash = args.mediaKeysToTrash || [];
+    const dedupKeys = args.dedupKeys
+    const mediaKeysToTrash = args.mediaKeysToTrash || []
+    const total = dedupKeys.length
+    const chunks = chunkArray(dedupKeys, BATCH_SIZE)
     console.log(
-      "GPD: Trashing",
-      dedupKeys.length,
-      "items via api.moveItemsToTrash",
-    );
-    await api.moveItemsToTrash(dedupKeys);
+      `[GPD] trash: ${total} items, ${chunks.length} chunk(s) of ${BATCH_SIZE}`
+    )
+
+    // Chunk to avoid HTTP 504 Gateway Timeout on large batches (fixes #107).
+    let trashed = 0
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i]
+      await api.moveItemsToTrash(chunk)
+      trashed += chunk.length
+      console.log(
+        `[GPD] trash chunk ${i + 1}/${chunks.length}: ${trashed}/${total} done`
+      )
+      postProgress(
+        requestId,
+        trashed,
+        `Moved ${trashed} of ${total} items to trash`,
+        "trashItems"
+      )
+    }
+
+    console.log(`[GPD] trash complete: ${total} items moved`)
     postResult("trashItems", requestId, {
-      trashedCount: dedupKeys.length,
-      trashedKeys: mediaKeysToTrash,
-    });
+      trashedCount: total,
+      trashedKeys: mediaKeysToTrash
+    })
   } catch (error) {
-    console.error("GPD: Trash error", error);
-    postError("trashItems", requestId, error);
+    console.error("[GPD] trash error:", error)
+    postError("trashItems", requestId, error)
   }
 }
 
@@ -158,24 +190,46 @@ async function trashItems(requestId, args) {
 async function restoreItems(requestId, args) {
   // Call api.restoreFromTrash directly (same reason as trashItems —
   // executeWithConcurrency checks isProcessRunning which is always false here).
-  const api = window.gptkApiUtils?.api;
+  const api = window.gptkApiUtils?.api
   if (!api) {
     postError(
       "restoreItems",
       requestId,
-      "GPTK API not available. Reload the Google Photos page.",
-    );
-    return;
+      "GPTK API not available. Reload the Google Photos page."
+    )
+    return
   }
 
   try {
-    const dedupKeys = args.dedupKeys;
-    console.log("GPD: Restoring", dedupKeys.length, "items from trash");
-    await api.restoreFromTrash(dedupKeys);
-    postResult("restoreItems", requestId, { restoredCount: dedupKeys.length });
+    const dedupKeys = args.dedupKeys
+    const total = dedupKeys.length
+    const chunks = chunkArray(dedupKeys, BATCH_SIZE)
+    console.log(
+      `[GPD] restore: ${total} items, ${chunks.length} chunk(s) of ${BATCH_SIZE}`
+    )
+
+    // Chunk to avoid HTTP 504 Gateway Timeout on large batches.
+    let restored = 0
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i]
+      await api.restoreFromTrash(chunk)
+      restored += chunk.length
+      console.log(
+        `[GPD] restore chunk ${i + 1}/${chunks.length}: ${restored}/${total} done`
+      )
+      postProgress(
+        requestId,
+        restored,
+        `Restored ${restored} of ${total} items`,
+        "restoreItems"
+      )
+    }
+
+    console.log(`[GPD] restore complete: ${total} items restored`)
+    postResult("restoreItems", requestId, { restoredCount: total })
   } catch (error) {
-    console.error("GPD: Restore error", error);
-    postError("restoreItems", requestId, error);
+    console.error("[GPD] restore error:", error)
+    postError("restoreItems", requestId, error)
   }
 }
 
@@ -185,11 +239,11 @@ async function restoreItems(requestId, args) {
 // ============================================================
 
 function healthCheck(requestId) {
-  const hasGptk = typeof window.gptkApi !== "undefined";
-  const hasWizData = typeof window.WIZ_global_data !== "undefined";
+  const hasGptk = typeof window.gptkApi !== "undefined"
+  const hasWizData = typeof window.WIZ_global_data !== "undefined"
   // oPEP7c is the signed-in account email in WIZ_global_data
-  const accountEmail = hasWizData ? window.WIZ_global_data.oPEP7c || "" : "";
-  postResult("healthCheck", requestId, { hasGptk, hasWizData, accountEmail });
+  const accountEmail = hasWizData ? window.WIZ_global_data.oPEP7c || "" : ""
+  postResult("healthCheck", requestId, { hasGptk, hasWizData, accountEmail })
 }
 
 // ============================================================
@@ -197,29 +251,29 @@ function healthCheck(requestId) {
 // ============================================================
 
 window.addEventListener("message", async (event) => {
-  if (event.source !== window) return;
-  const msg = event.data;
-  if (msg?.app !== GPD_APP_ID || msg?.action !== "gptkCommand") return;
+  if (event.source !== window) return
+  const msg = event.data
+  if (msg?.app !== GPD_APP_ID || msg?.action !== "gptkCommand") return
 
-  const { command, requestId, args } = msg;
-  console.log("GPD: Received command", command, requestId);
+  const { command, requestId, args } = msg
+  console.log("GPD: Received command", command, requestId)
 
   switch (command) {
     case "getAllMediaItems":
-      await getAllMediaItems(requestId, args);
-      break;
+      await getAllMediaItems(requestId, args)
+      break
     case "trashItems":
-      await trashItems(requestId, args);
-      break;
+      await trashItems(requestId, args)
+      break
     case "restoreItems":
-      await restoreItems(requestId, args);
-      break;
+      await restoreItems(requestId, args)
+      break
     case "healthCheck":
-      healthCheck(requestId);
-      break;
+      healthCheck(requestId)
+      break
     default:
-      postError(command, requestId, `Unknown command: ${command}`);
+      postError(command, requestId, `Unknown command: ${command}`)
   }
-});
+})
 
-console.log("GPD: Command handler loaded");
+console.log("GPD: Command handler loaded")

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -4,6 +4,7 @@ import AppBar from "@mui/material/AppBar"
 import Box from "@mui/material/Box"
 import Button from "@mui/material/Button"
 import CircularProgress from "@mui/material/CircularProgress"
+import LinearProgress from "@mui/material/LinearProgress"
 import CssBaseline from "@mui/material/CssBaseline"
 import Dialog from "@mui/material/Dialog"
 import DialogActions from "@mui/material/DialogActions"
@@ -254,12 +255,18 @@ export default function App() {
             dispatch({ type: "GP_TAB_CLOSED" })
           }
           break
-        case "gptkProgress":
-          dispatch({
-            type: "SCAN_PROGRESS",
-            payload: message as GptkProgressMessage
-          })
+        case "gptkProgress": {
+          const progress = message as GptkProgressMessage
+          if (progress.command === "trashItems") {
+            console.log(`[GPD] trash progress: ${progress.itemsProcessed}`)
+            dispatch({ type: "TRASH_PROGRESS", trashedSoFar: progress.itemsProcessed })
+          } else if (progress.command === "restoreItems") {
+            console.log(`[GPD] restore progress: ${progress.itemsProcessed}`)
+          } else {
+            dispatch({ type: "SCAN_PROGRESS", payload: progress })
+          }
           break
+        }
       }
     }
 
@@ -682,18 +689,22 @@ export default function App() {
         )}
 
         {state.status === "trashing" && (
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              pt: 8,
-              gap: 2
-            }}>
-            <CircularProgress size={28} />
-            <Typography variant="body2" color="text.secondary">
-              Moving items to trash…
+          <Box sx={{ maxWidth: 480, mx: "auto", p: 4 }}>
+            <Typography variant="h5" fontWeight={600} gutterBottom>
+              Moving to Trash
             </Typography>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
+              <CircularProgress size={14} thickness={5} />
+              <Typography variant="body2" color="text.secondary">
+                {state.trashedSoFar > 0
+                  ? `${state.trashedSoFar.toLocaleString()} of ${state.totalToTrash.toLocaleString()} moved`
+                  : "Starting…"}
+              </Typography>
+            </Box>
+            <LinearProgress
+              variant={state.trashedSoFar > 0 ? "determinate" : "indeterminate"}
+              value={Math.round((state.trashedSoFar / state.totalToTrash) * 100)}
+            />
           </Box>
         )}
       </Box>

--- a/tests/commands/google-photos-commands.test.ts
+++ b/tests/commands/google-photos-commands.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for scripts/google-photos-commands.js
+ *
+ * The commands script runs in a MAIN world context — it registers a
+ * window "message" listener on import and uses window.postMessage to
+ * communicate results back to the bridge. Tests drive it by dispatching
+ * MessageEvents and inspecting postMessage calls.
+ *
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest"
+
+// ============================================================
+// Globals the script expects at runtime
+// ============================================================
+
+const mockMoveItemsToTrash = vi.fn()
+const mockRestoreFromTrash = vi.fn()
+
+const mockApi = {
+  moveItemsToTrash: mockMoveItemsToTrash,
+  restoreFromTrash: mockRestoreFromTrash,
+}
+
+// Set up window globals BEFORE importing the module so the script
+// sees them when it first executes.
+Object.defineProperty(window, "gptkApiUtils", {
+  value: { api: mockApi },
+  writable: true,
+  configurable: true,
+})
+
+// ============================================================
+// Import the commands script (registers listener on window)
+// ============================================================
+
+beforeAll(async () => {
+  // google-photos-commands.js is a side-effect-only MAIN world script (no exports).
+  // We import it here purely to register its window "message" listener.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  await import("../../scripts/google-photos-commands.js")
+})
+
+// ============================================================
+// Helpers
+// ============================================================
+
+/** Dispatch a gptkCommand message the same way the bridge does. */
+function sendCommand(command: string, requestId: string, args: unknown) {
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      source: window,
+      data: { app: "GPD", action: "gptkCommand", command, requestId, args },
+    })
+  )
+}
+
+/** Collect window.postMessage calls during an async operation. */
+function collectMessages(): { messages: unknown[]; restore: () => void } {
+  const messages: unknown[] = []
+  const original = window.postMessage.bind(window)
+  const spy = vi.spyOn(window, "postMessage").mockImplementation((msg) => {
+    messages.push(msg)
+  })
+  return { messages, restore: () => spy.mockRestore() }
+}
+
+/** Wait for all queued microtasks / promise continuations to settle. */
+async function flush() {
+  await new Promise((r) => setTimeout(r, 0))
+}
+
+// ============================================================
+// Reset between tests
+// ============================================================
+
+beforeEach(() => {
+  mockMoveItemsToTrash.mockReset()
+  mockRestoreFromTrash.mockReset()
+  mockMoveItemsToTrash.mockResolvedValue(undefined)
+  mockRestoreFromTrash.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ============================================================
+// Unit tests: trashItems
+// ============================================================
+
+describe("trashItems — chunking", () => {
+  it("sends a single API call when items fit in one batch (≤ 250)", async () => {
+    const { messages, restore } = collectMessages()
+    const dedupKeys = Array.from({ length: 200 }, (_, i) => `dk-${i}`)
+
+    sendCommand("trashItems", "req-1", { dedupKeys, mediaKeysToTrash: [] })
+    await flush()
+
+    expect(mockMoveItemsToTrash).toHaveBeenCalledTimes(1)
+    expect(mockMoveItemsToTrash).toHaveBeenCalledWith(dedupKeys)
+
+    const result = messages.find(
+      (m: any) => m.action === "gptkResult" && m.command === "trashItems"
+    ) as any
+    expect(result?.success).toBe(true)
+    expect(result?.data?.trashedCount).toBe(200)
+    restore()
+  })
+
+  it("splits 550 items into 3 chunks: 250 + 250 + 50", async () => {
+    const { restore } = collectMessages()
+    const dedupKeys = Array.from({ length: 550 }, (_, i) => `dk-${i}`)
+
+    sendCommand("trashItems", "req-2", { dedupKeys, mediaKeysToTrash: [] })
+    await flush()
+
+    expect(mockMoveItemsToTrash).toHaveBeenCalledTimes(3)
+    expect(mockMoveItemsToTrash.mock.calls[0][0]).toHaveLength(250)
+    expect(mockMoveItemsToTrash.mock.calls[1][0]).toHaveLength(250)
+    expect(mockMoveItemsToTrash.mock.calls[2][0]).toHaveLength(50)
+    restore()
+  })
+
+  it("posts a progress message after each chunk", async () => {
+    const { messages, restore } = collectMessages()
+    const dedupKeys = Array.from({ length: 500 }, (_, i) => `dk-${i}`)
+
+    sendCommand("trashItems", "req-3", { dedupKeys, mediaKeysToTrash: [] })
+    await flush()
+
+    const progressMsgs = messages.filter(
+      (m: any) => m.action === "gptkProgress" && m.command === "trashItems"
+    ) as any[]
+
+    // One progress message per chunk (2 chunks for 500 items)
+    expect(progressMsgs).toHaveLength(2)
+    expect(progressMsgs[0].itemsProcessed).toBe(250)
+    expect(progressMsgs[1].itemsProcessed).toBe(500)
+    restore()
+  })
+
+  it("reports error and stops on first API failure", async () => {
+    mockMoveItemsToTrash.mockRejectedValueOnce(new Error("HTTP 504"))
+
+    const { messages, restore } = collectMessages()
+    const dedupKeys = Array.from({ length: 400 }, (_, i) => `dk-${i}`)
+
+    sendCommand("trashItems", "req-4", { dedupKeys, mediaKeysToTrash: [] })
+    await flush()
+
+    // Only called once — stops after the first failure
+    expect(mockMoveItemsToTrash).toHaveBeenCalledTimes(1)
+
+    const result = messages.find(
+      (m: any) => m.action === "gptkResult" && m.command === "trashItems"
+    ) as any
+    expect(result?.success).toBe(false)
+    expect(result?.error).toContain("HTTP 504")
+    restore()
+  })
+})
+
+// ============================================================
+// Unit tests: restoreItems
+// ============================================================
+
+describe("restoreItems — chunking", () => {
+  it("sends a single API call for ≤ 250 items", async () => {
+    const { restore } = collectMessages()
+    const dedupKeys = Array.from({ length: 100 }, (_, i) => `dk-${i}`)
+
+    sendCommand("restoreItems", "req-5", { dedupKeys })
+    await flush()
+
+    expect(mockRestoreFromTrash).toHaveBeenCalledTimes(1)
+    expect(mockRestoreFromTrash).toHaveBeenCalledWith(dedupKeys)
+    restore()
+  })
+
+  it("splits 750 items into 3 chunks: 250 + 250 + 250", async () => {
+    const { restore } = collectMessages()
+    const dedupKeys = Array.from({ length: 750 }, (_, i) => `dk-${i}`)
+
+    sendCommand("restoreItems", "req-6", { dedupKeys })
+    await flush()
+
+    expect(mockRestoreFromTrash).toHaveBeenCalledTimes(3)
+    for (const call of mockRestoreFromTrash.mock.calls) {
+      expect(call[0]).toHaveLength(250)
+    }
+    restore()
+  })
+
+  it("posts a progress message after each chunk", async () => {
+    const { messages, restore } = collectMessages()
+    const dedupKeys = Array.from({ length: 500 }, (_, i) => `dk-${i}`)
+
+    sendCommand("restoreItems", "req-7", { dedupKeys })
+    await flush()
+
+    const progressMsgs = messages.filter(
+      (m: any) => m.action === "gptkProgress" && m.command === "restoreItems"
+    ) as any[]
+
+    expect(progressMsgs).toHaveLength(2)
+    expect(progressMsgs[0].itemsProcessed).toBe(250)
+    expect(progressMsgs[1].itemsProcessed).toBe(500)
+    restore()
+  })
+})
+
+// ============================================================
+// Integration test: full trash flow with a realistic large batch
+// ============================================================
+
+describe("integration: trashItems full flow", () => {
+  it("chunks 1100 items into 5 batches, reports progress, and returns correct result", async () => {
+    const { messages, restore } = collectMessages()
+
+    const total = 1100
+    const dedupKeys = Array.from({ length: total }, (_, i) => `dedup-${i}`)
+    const mediaKeysToTrash = Array.from({ length: total }, (_, i) => `media-${i}`)
+
+    sendCommand("trashItems", "req-int-1", { dedupKeys, mediaKeysToTrash })
+    await flush()
+
+    // 1100 / 250 = 4 full chunks + 1 remainder of 100 → 5 calls
+    expect(mockMoveItemsToTrash).toHaveBeenCalledTimes(5)
+    expect(mockMoveItemsToTrash.mock.calls[0][0]).toHaveLength(250)
+    expect(mockMoveItemsToTrash.mock.calls[1][0]).toHaveLength(250)
+    expect(mockMoveItemsToTrash.mock.calls[2][0]).toHaveLength(250)
+    expect(mockMoveItemsToTrash.mock.calls[3][0]).toHaveLength(250)
+    expect(mockMoveItemsToTrash.mock.calls[4][0]).toHaveLength(100)
+
+    // Keys are passed in order and cover the full set
+    const allSentKeys = mockMoveItemsToTrash.mock.calls.flatMap((c) => c[0])
+    expect(allSentKeys).toEqual(dedupKeys)
+
+    // 5 progress messages, monotonically increasing
+    const progressMsgs = messages.filter(
+      (m: any) => m.action === "gptkProgress" && m.command === "trashItems"
+    ) as any[]
+    expect(progressMsgs).toHaveLength(5)
+    expect(progressMsgs.map((p: any) => p.itemsProcessed)).toEqual([
+      250, 500, 750, 1000, 1100,
+    ])
+
+    // Final result message
+    const result = messages.find(
+      (m: any) => m.action === "gptkResult" && m.command === "trashItems"
+    ) as any
+    expect(result?.success).toBe(true)
+    expect(result?.data?.trashedCount).toBe(total)
+    expect(result?.data?.trashedKeys).toEqual(mediaKeysToTrash)
+
+    restore()
+  })
+})

--- a/tests/lib/app-reducer.test.ts
+++ b/tests/lib/app-reducer.test.ts
@@ -57,6 +57,7 @@ const trashingState: AppState = {
   groups,
   totalItems: 4,
   totalToTrash: 2,
+  trashedSoFar: 0,
 }
 
 // ============================================================
@@ -150,6 +151,23 @@ describe("SCAN_ERROR", () => {
 })
 
 // ============================================================
+// TRASH_PROGRESS
+// ============================================================
+
+describe("TRASH_PROGRESS", () => {
+  it("updates trashedSoFar while in trashing state", () => {
+    const next = appReducer(trashingState, { type: "TRASH_PROGRESS", trashedSoFar: 250 })
+    expect(next.status).toBe("trashing")
+    if (next.status === "trashing") expect(next.trashedSoFar).toBe(250)
+  })
+
+  it("is a no-op outside trashing state", () => {
+    const next = appReducer(resultsState, { type: "TRASH_PROGRESS", trashedSoFar: 250 })
+    expect(next).toBe(resultsState)
+  })
+})
+
+// ============================================================
 // TRASH_COMPLETE — critical: correct items removed, groups collapsed
 // ============================================================
 
@@ -185,6 +203,7 @@ describe("TRASH_COMPLETE", () => {
       groups: [threeItemGroup],
       totalItems: 3,
       totalToTrash: 1,
+      trashedSoFar: 0,
     }
     const next = appReducer(state, {
       type: "TRASH_COMPLETE",


### PR DESCRIPTION
Fixes #107

## Problem

Sending all dedup keys in a single API request caused Google's `batchexecute` endpoint to return **HTTP 504 Gateway Timeout** when trashing or restoring large numbers of items (e.g. 10k duplicates). The retry logic in `Api.makeApiRequest` exhausted all 3 attempts and the operation failed entirely.

Root cause: `google-photos-commands.js` called `api.moveItemsToTrash(allDedupKeys)` in one shot. GPTK's own `ApiUtils.moveToTrash()` correctly chunks into 250-item batches via `executeWithConcurrency`, but we can't use that path because it checks `core.isProcessRunning` (always `false` when called from the extension, since we never go through `Core.run()`).

## Changes

**`scripts/google-photos-commands.js`**
- Added `BATCH_SIZE = 250` (matches GPTK's default `operationSize`)
- Added `chunkArray()` helper
- `trashItems`: iterates chunks, calls `api.moveItemsToTrash` per chunk, posts `gptkProgress` with `command: "trashItems"` after each
- `restoreItems`: same chunking + `gptkProgress` with `command: "restoreItems"`
- Updated `postProgress` to accept optional `command` arg
- `[GPD]` console logs per chunk in the Google Photos tab console

**`lib/types.ts`**
- Added `command?: string` to `GptkProgressMessage` so the app can route progress to the right handler

**`lib/app-reducer.ts`**
- Added `trashedSoFar: number` to `trashing` state
- Added `TRASH_PROGRESS` action — updates `trashedSoFar`, no-op outside trashing state

**`tabs/app.tsx`**
- Progress handler dispatches `TRASH_PROGRESS` when `command === "trashItems"`, logs restore progress, falls through to `SCAN_PROGRESS` otherwise
- Trashing UI replaced with a `LinearProgress` bar — indeterminate until first chunk lands, then determinate with `X of Y moved` count
- `[GPD] trash progress` / `[GPD] restore progress` logs in the app tab console

**`package.json`**
- `build:worker` now runs in `dev` so the embedder worker is always fresh

**`tests/commands/google-photos-commands.test.ts`** (new)
- 7 unit tests: single-chunk path, multi-chunk splits, progress message count/values, error stops early, restore chunking + progress
- 1 integration test: 1,100 items → 5 API calls in correct order, 5 progress messages with monotonically increasing counts, correct final result

**`tests/lib/app-reducer.test.ts`**
- Fixed `trashingState` fixture to include `trashedSoFar: 0`
- Added 2 tests for `TRASH_PROGRESS`
