### PR TITLE
Persist selections to chrome.storage.local across page reloads

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -186,6 +186,10 @@ export interface StoredState {
     totalItems: number;
     newestCreationTimestamp?: number; // for incremental fetch on next scan
   };
+  selections?: {
+    selectedGroupIds: string[];
+    keptOverrides: Record<string, string[]>;
+  };
   settings: ScanSettings;
 }
 

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -117,6 +117,12 @@ export default function App() {
   // scans killed by reload can be dropped (they arrive late from the GP tab)
   const currentScanRequestIdRef = useRef<string | null>(null)
 
+  // Holds selections loaded from storage; applied once when groups first load
+  const pendingSelectionsRef = useRef<{
+    selectedGroupIds: Set<string>
+    keptOverrides: Record<string, Set<string>>
+  } | null>(null)
+
   // Sync selectedGroupIds when groups change (e.g. after scan or trash)
   const stateGroups =
     state.status === "results" || state.status === "trashing"
@@ -124,8 +130,23 @@ export default function App() {
       : null
   const groups = useMemo(() => stateGroups ?? [], [stateGroups])
   useEffect(() => {
-    setSelectedGroupIds(new Set(groups.map((g) => g.id)))
-    setKeptOverrides({})
+    if (pendingSelectionsRef.current) {
+      const saved = pendingSelectionsRef.current
+      pendingSelectionsRef.current = null
+      const validIds = new Set(groups.map((g) => g.id))
+      // Restore saved selection, filtered to groups that still exist
+      const next = new Set([...saved.selectedGroupIds].filter((id) => validIds.has(id)))
+      setSelectedGroupIds(next)
+      // Restore kept overrides, filtered to valid groups
+      const filteredKept: Record<string, Set<string>> = {}
+      for (const [id, keys] of Object.entries(saved.keptOverrides)) {
+        if (validIds.has(id)) filteredKept[id] = keys
+      }
+      setKeptOverrides(filteredKept)
+    } else {
+      setSelectedGroupIds(new Set(groups.map((g) => g.id)))
+      setKeptOverrides({})
+    }
   }, [groups])
 
   const getKept = useCallback(
@@ -362,10 +383,20 @@ export default function App() {
   // Load saved settings and results on mount
   useEffect(() => {
     chrome.storage.local.get(
-      ["settings", "scanResults"],
+      ["settings", "scanResults", "selections"],
       (result: Partial<StoredState>) => {
         if (result.settings) {
           setSettings(result.settings)
+        }
+        if (result.selections) {
+          // Store deserialized selections before dispatching LOAD_SAVED_RESULTS so
+          // the groups-change effect can apply them when groups first appear
+          pendingSelectionsRef.current = {
+            selectedGroupIds: new Set(result.selections.selectedGroupIds),
+            keptOverrides: Object.fromEntries(
+              Object.entries(result.selections.keptOverrides).map(([k, v]) => [k, new Set(v)])
+            ),
+          }
         }
         if (result.scanResults?.totalItems && Array.isArray(result.scanResults.groups)) {
           dispatch({
@@ -404,6 +435,23 @@ export default function App() {
       chrome.storage.local.remove("scanResults")
     }
   }, [groups, mediaItems, totalItems])
+
+  // Persist selections when they change (only while results are showing)
+  useEffect(() => {
+    if (state.status !== "results") return
+    if (groups.length === 0) {
+      chrome.storage.local.remove("selections")
+      return
+    }
+    chrome.storage.local.set({
+      selections: {
+        selectedGroupIds: [...selectedGroupIds],
+        keptOverrides: Object.fromEntries(
+          Object.entries(keptOverrides).map(([k, v]) => [k, [...v]])
+        ),
+      },
+    })
+  }, [selectedGroupIds, keptOverrides, state.status, groups.length])
 
   // Save settings on change
   useEffect(() => {

--- a/tests/e2e/fixtures/extension.ts
+++ b/tests/e2e/fixtures/extension.ts
@@ -134,6 +134,21 @@ export async function injectScanResults(
   )
 }
 
+export async function injectSelections(
+  context: BrowserContext,
+  selectedGroupIds: string[],
+  keptOverrides: Record<string, string[]> = {}
+): Promise<void> {
+  const sw = context.serviceWorkers()[0]
+  await sw.evaluate(
+    ({ selectedGroupIds, keptOverrides }) =>
+      new Promise<void>((resolve) => {
+        chrome.storage.local.set({ selections: { selectedGroupIds, keptOverrides } }, resolve)
+      }),
+    { selectedGroupIds, keptOverrides }
+  )
+}
+
 export async function clearStorage(context: BrowserContext): Promise<void> {
   let sw = context.serviceWorkers()[0]
   if (!sw) {

--- a/tests/e2e/integration/app-tab.test.ts
+++ b/tests/e2e/integration/app-tab.test.ts
@@ -10,6 +10,7 @@ import {
   launchExtension,
   openAppTab,
   injectScanResults,
+  injectSelections,
   clearStorage,
 } from "../fixtures/extension"
 
@@ -73,4 +74,78 @@ test("shows disconnected state when GP tab is not open and no saved results", as
   ).toBeVisible({ timeout: 8000 })
 
   await page.close()
+})
+
+// ============================================================
+// Selection persistence
+// ============================================================
+
+const BASE_MEDIA_ITEMS = {
+  key1: { mediaKey: "key1", dedupKey: "d1", thumb: "", timestamp: 0, creationTimestamp: 0, resWidth: 100, resHeight: 100, duration: null, isOwned: true, fileName: "photo1.jpg" },
+  key2: { mediaKey: "key2", dedupKey: "d2", thumb: "", timestamp: 0, creationTimestamp: 0, resWidth: 100, resHeight: 100, duration: null, isOwned: true, fileName: "photo2.jpg" },
+  key3: { mediaKey: "key3", dedupKey: "d3", thumb: "", timestamp: 0, creationTimestamp: 0, resWidth: 100, resHeight: 100, duration: null, isOwned: true, fileName: "photo3.jpg" },
+  key4: { mediaKey: "key4", dedupKey: "d4", thumb: "", timestamp: 0, creationTimestamp: 0, resWidth: 100, resHeight: 100, duration: null, isOwned: true, fileName: "photo4.jpg" },
+  key5: { mediaKey: "key5", dedupKey: "d5", thumb: "", timestamp: 0, creationTimestamp: 0, resWidth: 100, resHeight: 100, duration: null, isOwned: true, fileName: "photo5.jpg" },
+  key6: { mediaKey: "key6", dedupKey: "d6", thumb: "", timestamp: 0, creationTimestamp: 0, resWidth: 100, resHeight: 100, duration: null, isOwned: true, fileName: "photo6.jpg" },
+}
+
+test("persists group selections through page reload", async () => {
+  // 3 groups; only g1 and g3 are selected (g2 is deselected)
+  await injectScanResults(
+    context,
+    [
+      { id: "g1", mediaKeys: ["key1", "key2"], originalMediaKey: "key1", similarity: 0.99 },
+      { id: "g2", mediaKeys: ["key3", "key4"], originalMediaKey: "key3", similarity: 0.98 },
+      { id: "g3", mediaKeys: ["key5", "key6"], originalMediaKey: "key5", similarity: 0.97 },
+    ],
+    BASE_MEDIA_ITEMS,
+    6
+  )
+  await injectSelections(context, ["g1", "g3"], {})
+
+  const page = await openAppTab(context, extensionId)
+  await expect(page.getByText("3 Duplicate Groups Found")).toBeVisible({ timeout: 5000 })
+
+  const checkboxes = page.locator('input[type="checkbox"]')
+  await expect(checkboxes.nth(0)).toBeChecked()          // g1 selected
+  await expect(checkboxes.nth(1)).not.toBeChecked()      // g2 deselected
+  await expect(checkboxes.nth(2)).toBeChecked()          // g3 selected
+
+  await page.reload()
+  await expect(page.getByText("3 Duplicate Groups Found")).toBeVisible({ timeout: 5000 })
+  await expect(checkboxes.nth(0)).toBeChecked()
+  await expect(checkboxes.nth(1)).not.toBeChecked()
+  await expect(checkboxes.nth(2)).toBeChecked()
+
+  await page.close()
+  await clearStorage(context)
+})
+
+test("persists kept overrides through page reload", async () => {
+  // g1 has 2 items; default keep is key1 but we override to keep key2 instead
+  await injectScanResults(
+    context,
+    [
+      { id: "g1", mediaKeys: ["key1", "key2"], originalMediaKey: "key1", similarity: 0.99 },
+    ],
+    { key1: BASE_MEDIA_ITEMS.key1, key2: BASE_MEDIA_ITEMS.key2 },
+    2
+  )
+  await injectSelections(context, ["g1"], { g1: ["key2"] })
+
+  const page = await openAppTab(context, extensionId)
+  await expect(page.getByText("1 Duplicate Group Found")).toBeVisible({ timeout: 5000 })
+
+  // key2 (second card) should have the Keep chip; key1 (first card) should not
+  const cards = page.locator('.MuiCard-root')
+  await expect(cards.nth(0)).not.toContainText("Keep")  // key1 — not kept
+  await expect(cards.nth(1)).toContainText("Keep")      // key2 — kept
+
+  await page.reload()
+  await expect(page.getByText("1 Duplicate Group Found")).toBeVisible({ timeout: 5000 })
+  await expect(cards.nth(0)).not.toContainText("Keep")
+  await expect(cards.nth(1)).toContainText("Keep")
+
+  await page.close()
+  await clearStorage(context)
 })


### PR DESCRIPTION
## Summary

- Saves `selectedGroupIds` and `keptOverrides` to `chrome.storage.local` so both group-level and item-level selections survive a page reload
- On mount, stored selections are deserialized and applied when scan results load (via a `pendingSelectionsRef` consumed once by the groups-change effect)
- Selections are cleared from storage automatically when all groups are removed after a trash operation

## Test plan

- [x] `persists group selections through page reload` — deselects one of three groups, reloads, verifies the deselected state is restored
- [x] `persists kept overrides through page reload` — overrides the kept item within a group, reloads, verifies the correct photo shows the Keep chip
- [x] All 5 existing integration tests still pass