### PR TITLE
Clear stale results and refresh email when account changes

### DIFF
--- a/background/index.ts
+++ b/background/index.ts
@@ -74,7 +74,12 @@ async function sendGptkCommand(
 
   return new Promise((resolve, reject) => {
     pendingCommands[requestId] = { resolve, reject, appTabId: 0 }
-    chrome.tabs.sendMessage(gpTabId, message)
+    chrome.tabs.sendMessage(gpTabId, message).catch(() => {
+      delete pendingCommands[requestId]
+      reject(
+        "Unable to connect to Google Photos tab. Please reload the tab and try again."
+      )
+    })
   })
 }
 
@@ -205,7 +210,18 @@ async function handleGptkCommand(
   }
 
   // Forward the command to the GP tab (bridge will relay to MAIN world)
-  chrome.tabs.sendMessage(gpTabId, message)
+  chrome.tabs.sendMessage(gpTabId, message).catch(() => {
+    chrome.tabs.sendMessage(senderTabId, {
+      app: APP_ID,
+      action: "gptkResult",
+      command: message.command,
+      requestId: message.requestId,
+      success: false,
+      error:
+        "Unable to connect to Google Photos tab. Please reload the tab and try again.",
+    } as GptkResultMessage)
+    delete pendingCommands[message.requestId]
+  })
 }
 
 function handleGptkResult(

--- a/lib/app-reducer.ts
+++ b/lib/app-reducer.ts
@@ -71,6 +71,7 @@ export type AppAction =
       mediaItems: Record<string, GpdMediaItem>
       groups: DuplicateGroup[]
       totalItems: number
+      accountEmail?: string
     }
   | {
       type: "RESTORE_SNAPSHOT"
@@ -207,6 +208,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         mediaItems: action.mediaItems,
         groups: action.groups,
         totalItems: action.totalItems,
+        accountEmail: action.accountEmail,
       }
 
     case "RESTORE_SNAPSHOT":

--- a/lib/app-reducer.ts
+++ b/lib/app-reducer.ts
@@ -8,6 +8,7 @@ import type {
   GptkProgressMessage,
   ScanPhase,
 } from "./types"
+import { areScanResultsValid } from "./scan-results"
 
 // ============================================================
 // Types
@@ -92,6 +93,10 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       if (action.payload.success) {
         // Don't downgrade from results — just confirm GP is still available
         if (state.status === "results") {
+          // Clear stale results when a different account is detected
+          if (!areScanResultsValid({ accountEmail: state.accountEmail }, { accountEmail: action.payload.accountEmail })) {
+            return { status: "connected", hasGptk: action.payload.hasGptk, accountEmail: action.payload.accountEmail }
+          }
           const email = action.payload.accountEmail ?? state.accountEmail
           if (email === state.accountEmail) return state
           return { ...state, accountEmail: email }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -185,6 +185,7 @@ export interface StoredState {
     scanDate: number;
     totalItems: number;
     newestCreationTimestamp?: number; // for incremental fetch on next scan
+    accountEmail?: string;
   };
   selections?: {
     selectedGroupIds: string[];

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "test:integration": "playwright test --config playwright.config.ts",
     "test:e2e": "playwright test --config playwright.e2e.config.ts",
     "sync:scripts": "cp scripts/google-photos-commands.js build/chrome-mv3-dev/scripts/ 2>/dev/null || true",
-    "dev": "npm run build:gptk && npm run copy:wasm && npm run build:worker && plasmo dev",
-    "prebuild": "npm run build:gptk && npm run copy:wasm && npm run build:worker && npm run sync:scripts",
-    "build": "npm run build:gptk && npm run copy:wasm && npm run build:worker && plasmo build && cp -r build/chrome-mv3-prod/. build/chrome-mv3-dev/",
+    "predev": "npm run build:gptk && npm run copy:wasm && npm run build:worker && npm run sync:scripts",
+    "dev": "plasmo dev",
+    "prebuild": "npm run build:gptk && npm run copy:wasm && npm run build:worker",
+    "build": "plasmo build && cp -r build/chrome-mv3-prod/. build/chrome-mv3-dev/",
     "package": "npm run build && plasmo package",
     "release": "bash tools/release.sh"
   },

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -295,9 +295,11 @@ export default function App() {
     return () => chrome.runtime.onMessage.removeListener(listener)
   }, [])
 
-  // Keep a ref to settings so async callbacks see latest values
+  // Keep refs so async callbacks always see latest values
   const settingsRef = useRef(settings)
   settingsRef.current = settings
+  const stateRef = useRef(state)
+  stateRef.current = state
 
   // Run MediaPipe duplicate detection on fetched media items
   const runDuplicateDetection = useCallback(
@@ -399,7 +401,8 @@ export default function App() {
             type: "LOAD_SAVED_RESULTS",
             mediaItems: result.scanResults.mediaItems,
             groups: result.scanResults.groups,
-            totalItems: result.scanResults.totalItems
+            totalItems: result.scanResults.totalItems,
+            accountEmail: result.scanResults.accountEmail
           })
         }
         setStorageChecked(true)
@@ -410,6 +413,7 @@ export default function App() {
   // Persist scan results when they change (after scan or trash)
   const mediaItems = state.status === "results" ? state.mediaItems : null
   const totalItems = state.status === "results" ? state.totalItems : 0
+  const accountEmailForStorage = state.status === "results" ? state.accountEmail : undefined
   useEffect(() => {
     if (!mediaItems) return
     if (groups.length > 0) {
@@ -423,14 +427,15 @@ export default function App() {
           groups,
           scanDate: Date.now(),
           totalItems,
-          newestCreationTimestamp
+          newestCreationTimestamp,
+          accountEmail: accountEmailForStorage
         }
       })
     } else {
       // All duplicates removed — clear saved results so next open starts fresh
       chrome.storage.local.remove("scanResults")
     }
-  }, [groups, mediaItems, totalItems])
+  }, [groups, mediaItems, totalItems, accountEmailForStorage])
 
   // Persist selections when they change (only while results are showing)
   useEffect(() => {
@@ -461,10 +466,11 @@ export default function App() {
 
     const requestId = generateRequestId()
     currentScanRequestIdRef.current = requestId
-    const hasGptk = state.status === "connected" ? state.hasGptk : true
+    const currentState = stateRef.current
+    const hasGptk = currentState.status === "connected" ? currentState.hasGptk : true
     const accountEmail =
-      state.status === "connected" || state.status === "results"
-        ? state.accountEmail
+      currentState.status === "connected" || currentState.status === "results"
+        ? currentState.accountEmail
         : undefined
     dispatch({ type: "SCAN_STARTED", requestId, hasGptk, accountEmail })
 

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -319,10 +319,6 @@ export default function App() {
           })
         }
 
-        console.log(
-          `[GPD] starting scan: mode=${settingsRef.current.scanMode}, threshold=${settingsRef.current.similarityThreshold}`
-        )
-
         const groups =
           settingsRef.current.scanMode === "smart"
             ? await smartDetectDuplicates(
@@ -471,6 +467,10 @@ export default function App() {
         ? state.accountEmail
         : undefined
     dispatch({ type: "SCAN_STARTED", requestId, hasGptk, accountEmail })
+
+    console.log(
+      `[GPD] starting scan: mode=${settings.scanMode}, threshold=${settings.similarityThreshold}`
+    )
 
     // Load cached media items for incremental fetch. On a repeat scan we only
     // fetch items newer than the most-recently-seen upload timestamp.

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -34,6 +34,7 @@ import type { DetectionProgress } from "../lib/duplicate-detector"
 import { ScanLogger } from "../lib/scan-log"
 import theme from "../lib/theme"
 import { APP_ID, DEFAULT_SETTINGS } from "../lib/types"
+import { areScanResultsValid } from "../lib/scan-results"
 import type {
   AppMessage,
   DuplicateGroup,
@@ -355,6 +356,9 @@ export default function App() {
           mediaItems: mediaItemMap,
           groups
         })
+        // Refresh account email after scan — the email in state may be stale
+        // if the user switched accounts since the last health check.
+        sendToServiceWorker({ app: APP_ID, action: "healthCheck" })
       } catch (error) {
         currentScanRequestIdRef.current = null
         if (error instanceof DOMException && error.name === "AbortError") {
@@ -487,7 +491,11 @@ export default function App() {
         "scanResults"
       )) as Partial<StoredState>
       const prev = stored.scanResults
-      if (prev?.mediaItems && Object.keys(prev.mediaItems).length > 0) {
+      if (
+        prev?.mediaItems &&
+        Object.keys(prev.mediaItems).length > 0 &&
+        areScanResultsValid(prev, { accountEmail })
+      ) {
         cachedMediaItemsRef.current = prev.mediaItems
         // Compute watermark if not stored (migration: first run after this deploy)
         sinceTimestamp =

--- a/tests/background/service-worker.test.ts
+++ b/tests/background/service-worker.test.ts
@@ -135,6 +135,7 @@ describe("healthCheck", () => {
           )
         }, 0)
       }
+      return Promise.resolve()
     })
 
     dispatchMessage({ app: APP_ID, action: "healthCheck" }, appSender())

--- a/tests/lib/app-reducer.test.ts
+++ b/tests/lib/app-reducer.test.ts
@@ -105,6 +105,26 @@ describe("HEALTH_CHECK_RESULT", () => {
     expect(next.status).toBe("results")
     expect(next).toBe(resultsState)
   })
+
+  it("clears results and moves to connected when a different account is detected", () => {
+    const state: AppState = { status: "results", mediaItems, groups, totalItems: 4, accountEmail: "alice@example.com" }
+    const next = appReducer(state, {
+      type: "HEALTH_CHECK_RESULT",
+      payload: { app: APP_ID, action: "healthCheck.result", success: true, hasGptk: true, accountEmail: "bob@example.com" },
+    })
+    expect(next.status).toBe("connected")
+    expect((next as { accountEmail?: string }).accountEmail).toBe("bob@example.com")
+  })
+
+  it("keeps results when the same account reconnects", () => {
+    const state: AppState = { status: "results", mediaItems, groups, totalItems: 4, accountEmail: "alice@example.com" }
+    const next = appReducer(state, {
+      type: "HEALTH_CHECK_RESULT",
+      payload: { app: APP_ID, action: "healthCheck.result", success: true, hasGptk: true, accountEmail: "alice@example.com" },
+    })
+    expect(next.status).toBe("results")
+    expect(next).toBe(state)
+  })
 })
 
 // ============================================================


### PR DESCRIPTION
## Summary

- When a health check detects a different account than the one that produced the current results, reset to connected state (discarding the stale results)
- Fire a health check after scan completes so the email shown in the top right always reflects the current signed-in user, not whatever was in state at scan start
- Skip the incremental media cache when it belongs to a different account

## Test plan

- [x] Scan as one account, switch to a different Google account in the GP tab, then re-scan — results should be fresh with the new account's email shown
- [x] Scan as one account, switch accounts, reopen the extension — stale results should be cleared and the new account's email shown
- [x] Scan normally (same account) — incremental cache should still be used as before
- [x] Unit tests pass: `npx vitest run tests/lib/app-reducer.test.ts`