### PR TITLE
Fix TypeScript errors

### DIFF
--- a/lib/duplicate-detector.ts
+++ b/lib/duplicate-detector.ts
@@ -617,7 +617,7 @@ async function fetchThumbnails(
         const url = entry.item.thumb + `=h${THUMB_HEIGHT}`;
         const response = await fetch(url, {
           credentials: "include",
-          signal: AbortSignal.any([
+          signal: (AbortSignal as typeof AbortSignal & { any(signals: AbortSignal[]): AbortSignal }).any([
             AbortSignal.timeout(fetchTimeoutMs),
             ...(signal ? [signal] : []),
           ]),

--- a/tests/lib/app-reducer.test.ts
+++ b/tests/lib/app-reducer.test.ts
@@ -135,7 +135,7 @@ describe("SCAN_STARTED", () => {
   it("enters scanning state with correct initial values", () => {
     const next = appReducer(
       { status: "connected", hasGptk: true },
-      { type: "SCAN_STARTED", requestId: "req-1" }
+      { type: "SCAN_STARTED", requestId: "req-1", hasGptk: true }
     )
     expect(next).toMatchObject({
       status: "scanning",
@@ -149,7 +149,7 @@ describe("SCAN_STARTED", () => {
 describe("SCAN_COMPLETE", () => {
   it("sets results with correct totalItems count", () => {
     const next = appReducer(
-      { status: "scanning", phase: "fetching", itemsProcessed: 0, totalEstimate: 0, message: "", requestId: "r" },
+      { status: "scanning", phase: "fetching", itemsProcessed: 0, totalEstimate: 0, message: "", requestId: "r", hasGptk: true },
       { type: "SCAN_COMPLETE", mediaItems, groups }
     )
     expect(next).toMatchObject({
@@ -163,7 +163,7 @@ describe("SCAN_COMPLETE", () => {
 describe("SCAN_ERROR", () => {
   it("enters disconnected state", () => {
     const next = appReducer(
-      { status: "scanning", phase: "fetching", itemsProcessed: 0, totalEstimate: 0, message: "", requestId: "r" },
+      { status: "scanning", phase: "fetching", itemsProcessed: 0, totalEstimate: 0, message: "", requestId: "r", hasGptk: true },
       { type: "SCAN_ERROR", error: "network failure" }
     )
     expect(next.status).toBe("disconnected")

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "plasmo/templates/tsconfig.base",
   "exclude": [
     "node_modules",
-    "workers"
+    "workers",
+    "vitest.config.ts"
   ],
   "include": [
     ".plasmo/index.d.ts",

--- a/window.d.ts
+++ b/window.d.ts
@@ -1,0 +1,3 @@
+declare interface Window {
+  gptkApi: unknown;
+}


### PR DESCRIPTION
## Summary

- **`getFormData.ts`** — add explicit casts to fix `string | string[]` narrowing issues
- **`parseDateFromFilename.test.ts`** — use `type` import for `ParsedDate` (required by `verbatimModuleSyntax`)
- **`duplicate-detector.ts`** — cast `AbortSignal` to expose `.any()`, which is missing from the TS 5.3 dom lib
- **`window.d.ts`** — create missing file (referenced in tsconfig) declaring `window.gptkApi` for E2E tests
- **`app-reducer.test.ts`** — add missing `hasGptk` field to scanning state test fixtures
- **`tsconfig.json`** — exclude `vitest.config.ts` from type checking (`@vitejs/plugin-react` v6 uses TS 5.4+ export syntax incompatible with TS 5.3)

## Test plan

- [x] `npx tsc --noEmit` passes with no errors