### PR TITLE
Add QA test coverage: unit, component, and integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@types/react-window": "^1.8.8",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/ui": "^4.1.2",
+        "fake-indexeddb": "^6.2.5",
         "happy-dom": "^20.8.9",
         "jsdom": "^29.0.1",
         "prettier": "3.2.4",
@@ -7895,6 +7896,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-fifo": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/react-window": "^1.8.8",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/ui": "^4.1.2",
+    "fake-indexeddb": "^6.2.5",
     "happy-dom": "^20.8.9",
     "jsdom": "^29.0.1",
     "prettier": "3.2.4",

--- a/tests/components/action-bar.test.tsx
+++ b/tests/components/action-bar.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Component tests for ActionBar.
+ *
+ * Covers:
+ * - Stats display (items scanned, group count)
+ * - Button visibility based on groupCount
+ * - "Move to Trash" button disabled when duplicateCount === 0
+ * - All callback props fire on the correct user action
+ */
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { ThemeProvider, createTheme } from "@mui/material/styles"
+import { ActionBar } from "../../components/ActionBar"
+
+const theme = createTheme()
+
+interface Props {
+  totalItems?: number
+  groupCount?: number
+  duplicateCount?: number
+  onSelectAll?: () => void
+  onDeselectAll?: () => void
+  onTrash?: () => void
+  onRescan?: () => void
+}
+
+function renderActionBar(props: Props = {}) {
+  const defaults = {
+    totalItems: 500,
+    groupCount: 3,
+    duplicateCount: 6,
+    onSelectAll: vi.fn(),
+    onDeselectAll: vi.fn(),
+    onTrash: vi.fn(),
+    onRescan: vi.fn(),
+  }
+  const merged = { ...defaults, ...props }
+  return {
+    ...render(
+      <ThemeProvider theme={theme}>
+        <ActionBar {...merged} />
+      </ThemeProvider>
+    ),
+    callbacks: merged,
+  }
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe("ActionBar", () => {
+  describe("stats display", () => {
+    it("shows the total items scanned count", () => {
+      renderActionBar({ totalItems: 12345 })
+      expect(screen.getByText("12,345 items scanned")).toBeInTheDocument()
+    })
+
+    it("shows the duplicate group count (plural)", () => {
+      renderActionBar({ groupCount: 5 })
+      expect(screen.getByText("5 duplicate groups")).toBeInTheDocument()
+    })
+
+    it("shows singular 'duplicate group' when groupCount is 1", () => {
+      renderActionBar({ groupCount: 1 })
+      expect(screen.getByText("1 duplicate group")).toBeInTheDocument()
+    })
+  })
+
+  describe("button visibility", () => {
+    it("does not render action buttons when groupCount is 0", () => {
+      renderActionBar({ groupCount: 0 })
+      expect(screen.queryByRole("button", { name: /Re-scan/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole("button", { name: /Select All/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole("button", { name: /Trash/i })).not.toBeInTheDocument()
+    })
+
+    it("renders action buttons when groupCount > 0", () => {
+      renderActionBar({ groupCount: 2 })
+      expect(screen.getByRole("button", { name: /Re-scan/i })).toBeInTheDocument()
+      // Use exact regex to avoid /Select All/i matching "Deselect All"
+      expect(screen.getByRole("button", { name: /^Select All$/i })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: /^Deselect All$/i })).toBeInTheDocument()
+    })
+  })
+
+  describe("Move to Trash button", () => {
+    it("is enabled when duplicateCount > 0", () => {
+      renderActionBar({ duplicateCount: 4 })
+      const btn = screen.getByRole("button", { name: /Move 4 Duplicates to Trash/i })
+      expect(btn).toBeEnabled()
+    })
+
+    it("is disabled when duplicateCount is 0", () => {
+      renderActionBar({ duplicateCount: 0 })
+      const btn = screen.getByRole("button", { name: /Move 0 Duplicates? to Trash/i })
+      expect(btn).toBeDisabled()
+    })
+
+    it("shows singular 'Duplicate' when duplicateCount is 1", () => {
+      renderActionBar({ duplicateCount: 1 })
+      expect(
+        screen.getByRole("button", { name: /Move 1 Duplicate to Trash/i })
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe("callbacks", () => {
+    it("calls onRescan when Re-scan is clicked", () => {
+      const { callbacks } = renderActionBar()
+      fireEvent.click(screen.getByRole("button", { name: /Re-scan/i }))
+      expect(callbacks.onRescan).toHaveBeenCalledOnce()
+    })
+
+    it("calls onSelectAll when Select All is clicked", () => {
+      const { callbacks } = renderActionBar()
+      fireEvent.click(screen.getByRole("button", { name: /^Select All$/i }))
+      expect(callbacks.onSelectAll).toHaveBeenCalledOnce()
+    })
+
+    it("calls onDeselectAll when Deselect All is clicked", () => {
+      const { callbacks } = renderActionBar()
+      fireEvent.click(screen.getByRole("button", { name: /Deselect All/i }))
+      expect(callbacks.onDeselectAll).toHaveBeenCalledOnce()
+    })
+
+    it("calls onTrash when Move to Trash is clicked", () => {
+      const { callbacks } = renderActionBar({ duplicateCount: 3 })
+      fireEvent.click(screen.getByRole("button", { name: /Move 3 Duplicates to Trash/i }))
+      expect(callbacks.onTrash).toHaveBeenCalledOnce()
+    })
+
+    it("does not call onTrash when button is disabled", () => {
+      const { callbacks } = renderActionBar({ duplicateCount: 0 })
+      const btn = screen.getByRole("button", { name: /Move 0 Duplicates? to Trash/i })
+      fireEvent.click(btn)
+      expect(callbacks.onTrash).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/components/scan-progress.test.tsx
+++ b/tests/components/scan-progress.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Component tests for ScanProgress.
+ *
+ * Covers:
+ * - Phase label for each ScanPhase value
+ * - Step number display
+ * - Progress bar mode (determinate vs. indeterminate)
+ * - Item counts in caption text
+ * - Cancel button visibility and callback
+ */
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { ThemeProvider, createTheme } from "@mui/material/styles"
+import { ScanProgress } from "../../components/ScanProgress"
+import type { ScanPhase } from "../../lib/types"
+
+const theme = createTheme()
+
+interface Props {
+  phase?: ScanPhase
+  itemsProcessed?: number
+  totalEstimate?: number
+  message?: string
+  onCancel?: (() => void) | undefined
+}
+
+function renderScanProgress(props: Props = {}) {
+  const defaults: Required<Props> = {
+    phase: "fetching",
+    itemsProcessed: 0,
+    totalEstimate: 0,
+    message: "",
+    onCancel: undefined,
+  }
+  const merged = { ...defaults, ...props }
+  return render(
+    <ThemeProvider theme={theme}>
+      <ScanProgress {...merged} />
+    </ThemeProvider>
+  )
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe("ScanProgress", () => {
+  describe("phase labels", () => {
+    const cases: [ScanPhase, string, number][] = [
+      ["fetching", "Fetching media items", 1],
+      ["downloading_thumbnails", "Downloading thumbnails", 2],
+      ["computing_embeddings", "Computing image similarity", 3],
+      ["detecting_duplicates", "Finding duplicate groups", 4],
+      ["complete", "Complete", 4],
+    ]
+
+    it.each(cases)("phase '%s' shows label '%s' (step %i)", (phase, label, step) => {
+      renderScanProgress({ phase })
+      expect(screen.getByText(label)).toBeInTheDocument()
+      expect(screen.getByText(`Step ${step} of 4`)).toBeInTheDocument()
+    })
+  })
+
+  describe("progress display", () => {
+    it("shows indeterminate progress bar when totalEstimate is 0", () => {
+      renderScanProgress({ itemsProcessed: 0, totalEstimate: 0 })
+      // Indeterminate: no percentage text shown
+      expect(screen.queryByText(/^\d+%$/)).not.toBeInTheDocument()
+    })
+
+    it("shows determinate progress bar when totalEstimate > 0", () => {
+      renderScanProgress({ itemsProcessed: 500, totalEstimate: 1000 })
+      // ScanProgress renders `{progress}%` text when isDeterminate is true
+      expect(screen.getByText("50%")).toBeInTheDocument()
+    })
+
+    it("shows processed count only when totalEstimate is 0", () => {
+      renderScanProgress({ itemsProcessed: 123, totalEstimate: 0 })
+      expect(screen.getByText("123 items processed")).toBeInTheDocument()
+    })
+
+    it("shows processed / total when totalEstimate > 0", () => {
+      renderScanProgress({ itemsProcessed: 300, totalEstimate: 1000 })
+      expect(screen.getByText("300 items processed / 1,000")).toBeInTheDocument()
+    })
+
+    it("formats large numbers with locale separators", () => {
+      renderScanProgress({ itemsProcessed: 12345, totalEstimate: 50000 })
+      expect(screen.getByText("12,345 items processed / 50,000")).toBeInTheDocument()
+    })
+  })
+
+  describe("cancel button", () => {
+    it("does not render Cancel button when onCancel is not provided", () => {
+      renderScanProgress({ onCancel: undefined })
+      expect(screen.queryByRole("button", { name: /cancel/i })).not.toBeInTheDocument()
+    })
+
+    it("renders Cancel button when onCancel is provided", () => {
+      renderScanProgress({ onCancel: vi.fn() })
+      expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument()
+    })
+
+    it("calls onCancel when Cancel button is clicked", () => {
+      const onCancel = vi.fn()
+      renderScanProgress({ onCancel })
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }))
+      expect(onCancel).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe("header", () => {
+    it("shows 'Scanning Library' heading", () => {
+      renderScanProgress()
+      expect(screen.getByText("Scanning Library")).toBeInTheDocument()
+    })
+  })
+})

--- a/tests/e2e/fixtures/extension.ts
+++ b/tests/e2e/fixtures/extension.ts
@@ -5,6 +5,7 @@
 import { chromium, type BrowserContext, type Page } from "@playwright/test"
 import path from "path"
 import fs from "fs"
+import type { DuplicateGroup, GpdMediaItem } from "../../../lib/types"
 
 export const extensionPath = path.resolve(__dirname, "../../../build/chrome-mv3-dev")
 
@@ -179,6 +180,126 @@ export async function injectGpAuth(context: BrowserContext): Promise<void> {
   const cookies = loadGpCookies()
   await context.addCookies(cookies)
 }
+
+// ============================================================
+// GPTK stub helpers (integration tests)
+// ============================================================
+
+const gptkStubHtml = fs.readFileSync(
+  path.resolve(__dirname, "gptk-stub.html"),
+  "utf-8"
+)
+
+/**
+ * Per-command response overrides for the GPTK stub.
+ * Set `success: false` to force a command to fail.
+ */
+export interface GptkOverrides {
+  trashItems?: { success: false; error: string }
+  restoreItems?: { success: false; error: string }
+  [command: string]: { success: false; error: string } | { data: unknown } | undefined
+}
+
+/**
+ * Intercept https://photos.google.com/* and serve the GPTK stub page.
+ * The extension's bridge content script is injected automatically because the
+ * intercepted URL matches the content script's "matches" pattern.
+ *
+ * Call this before opening the stub page. Returns the opened stub Page so tests
+ * can close it, inspect state, or inject overrides via page.evaluate().
+ *
+ * @param overrides  Per-command response overrides (e.g. force trashItems to fail)
+ */
+export async function openGptkStubPage(
+  context: BrowserContext,
+  overrides: GptkOverrides = {}
+): Promise<Page> {
+  // Intercept ALL requests to photos.google.com so the content script host loads
+  await context.route("https://photos.google.com/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: gptkStubHtml,
+    })
+  })
+
+  const page = await context.newPage()
+  await page.goto("https://photos.google.com/")
+
+  // Inject overrides so the stub responds as configured
+  if (Object.keys(overrides).length > 0) {
+    await page.evaluate((ov) => {
+      ;(window as unknown as { __gptkOverrides: GptkOverrides }).__gptkOverrides = ov
+    }, overrides)
+  }
+
+  return page
+}
+
+/**
+ * Wait for a given text or pattern to become visible on the app tab.
+ * Reloads the page once if not visible within `timeout / 2` ms, then waits again.
+ * This handles the case where the app tab loads before the stub page is ready.
+ */
+export async function waitForAppState(
+  page: Page,
+  matcher: string | RegExp,
+  timeout = 10_000
+): Promise<void> {
+  await page.waitForSelector(
+    typeof matcher === "string"
+      ? `text=${matcher}`
+      : `:text-matches(${matcher.source}, ${matcher.flags || "i"})`,
+    { timeout }
+  )
+}
+
+/**
+ * Build N duplicate groups where each group has `itemsPerGroup` items.
+ * Returns both the groups array and a matching mediaItems record.
+ *
+ * Total dedupKeys = N * itemsPerGroup — useful for constructing payloads
+ * that span multiple 250-item trash batches.
+ */
+export function makeGroups(
+  groupCount: number,
+  itemsPerGroup: number
+): { groups: DuplicateGroup[]; mediaItems: Record<string, GpdMediaItem> } {
+  const groups: DuplicateGroup[] = []
+  const mediaItems: Record<string, GpdMediaItem> = {}
+
+  for (let g = 0; g < groupCount; g++) {
+    const mediaKeys: string[] = []
+    for (let i = 0; i < itemsPerGroup; i++) {
+      const key = `group${g}-item${i}`
+      mediaKeys.push(key)
+      mediaItems[key] = {
+        mediaKey: key,
+        dedupKey: `dedup-${key}`,
+        thumb: "",
+        productUrl: `https://photos.google.com/photo/${key}`,
+        timestamp: 1_600_000_000_000 + g * 1000 + i,
+        creationTimestamp: 1_700_000_000_000 + g * 1000 + i,
+        resWidth: 1920,
+        resHeight: 1080,
+        fileName: `photo-${key}.jpg`,
+        isOwned: true,
+      }
+    }
+    groups.push({
+      id: `group-${g}`,
+      mediaKeys,
+      originalMediaKey: mediaKeys[0],
+      similarity: 0.95,
+    })
+  }
+
+  return { groups, mediaItems }
+}
+
+// ============================================================
+// Google Photos auth (full E2E only)
+// ============================================================
 
 function loadGpCookies() {
   if (process.env.GP_AUTH_COOKIES) {

--- a/tests/e2e/fixtures/gptk-stub.html
+++ b/tests/e2e/fixtures/gptk-stub.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<!--
+  GPTK Stub Page
+  ==============
+  A minimal Google Photos lookalike served via context.route() intercept on
+  https://photos.google.com/* in integration tests.
+
+  The extension's bridge content script (google-photos-bridge.ts) is injected
+  automatically because this page's URL matches the content script's "matches"
+  pattern. The bridge relays:
+    - gptkCommand  →  chrome.runtime.sendMessage → window.postMessage (incoming here)
+    - gptkResult   →  window.postMessage → chrome.runtime.sendMessage (outgoing here)
+
+  This stub listens for gptkCommand messages on window and replies with
+  pre-programmed gptkResult / gptkProgress responses. Override behaviour
+  by setting window.__gptkOverrides before navigation or via page.evaluate().
+
+  Supported commands:
+    healthCheck     → { hasGptk, hasWizData, accountEmail }
+    getAllMediaItems → []   (empty; scan tests use injected storage)
+    trashItems      → emits per-chunk gptkProgress + final gptkResult
+    restoreItems    → immediate gptkResult success
+
+  Force failure for any command by setting:
+    window.__gptkOverrides = { trashItems: { success: false, error: "..." } }
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Google Photos (stub)</title>
+</head>
+<body>
+  <p>Google Photos stub — integration test fixture</p>
+
+  <script>
+    const APP_ID = "GPD"
+    const BATCH_SIZE = 250
+
+    /**
+     * Per-command response overrides. Tests can inject:
+     *   await page.evaluate(() => {
+     *     window.__gptkOverrides = { trashItems: { success: false, error: "HTTP 504" } }
+     *   })
+     */
+    window.__gptkOverrides = window.__gptkOverrides || {}
+
+    /**
+     * Default programmed responses per command.
+     * These match the real GPTK response shapes captured from the live extension.
+     */
+    const DEFAULT_RESPONSES = {
+      healthCheck: {
+        hasGptk: true,
+        hasWizData: true,
+        accountEmail: "test@example.com",
+      },
+      getAllMediaItems: [],
+    }
+
+    function reply(command, requestId, data) {
+      window.postMessage({
+        app: APP_ID,
+        action: "gptkResult",
+        command,
+        requestId,
+        success: true,
+        data,
+      })
+    }
+
+    function replyError(command, requestId, error) {
+      window.postMessage({
+        app: APP_ID,
+        action: "gptkResult",
+        command,
+        requestId,
+        success: false,
+        error,
+      })
+    }
+
+    function progress(command, requestId, itemsProcessed) {
+      window.postMessage({
+        app: APP_ID,
+        action: "gptkProgress",
+        command,
+        requestId,
+        itemsProcessed,
+      })
+    }
+
+    async function handleTrashItems(command, requestId, args) {
+      const override = window.__gptkOverrides[command]
+      if (override && override.success === false) {
+        replyError(command, requestId, override.error || "Stub: trashItems failed")
+        return
+      }
+
+      const dedupKeys = (args && args.dedupKeys) || []
+      const mediaKeysToTrash = (args && args.mediaKeysToTrash) || dedupKeys
+
+      // Emit one gptkProgress per completed batch (mirroring real GPTK behaviour)
+      for (let i = BATCH_SIZE; i < dedupKeys.length; i += BATCH_SIZE) {
+        progress(command, requestId, Math.min(i, dedupKeys.length))
+        // Yield to allow the bridge to relay before the next iteration
+        await new Promise((r) => setTimeout(r, 0))
+      }
+
+      // Final progress (full count) + result
+      progress(command, requestId, dedupKeys.length)
+      reply(command, requestId, {
+        trashedCount: dedupKeys.length,
+        trashedKeys: mediaKeysToTrash,
+      })
+    }
+
+    async function handleRestoreItems(command, requestId, args) {
+      const override = window.__gptkOverrides[command]
+      if (override && override.success === false) {
+        replyError(command, requestId, override.error || "Stub: restoreItems failed")
+        return
+      }
+      reply(command, requestId, {})
+    }
+
+    window.addEventListener("message", async (event) => {
+      if (event.source !== window) return
+      const msg = event.data
+      if (!msg || msg.app !== APP_ID || msg.action !== "gptkCommand") return
+
+      const { command, requestId, args } = msg
+
+      switch (command) {
+        case "trashItems":
+          await handleTrashItems(command, requestId, args)
+          break
+
+        case "restoreItems":
+          await handleRestoreItems(command, requestId, args)
+          break
+
+        default: {
+          const override = window.__gptkOverrides[command]
+          if (override && override.success === false) {
+            replyError(command, requestId, override.error || `Stub: ${command} failed`)
+          } else {
+            const data = (override && override.data) || DEFAULT_RESPONSES[command] || null
+            reply(command, requestId, data)
+          }
+        }
+      }
+    })
+
+    console.log("[GPD stub] GPTK stub page loaded — ready for gptkCommand messages")
+  </script>
+</body>
+</html>

--- a/tests/e2e/fixtures/real-scan-sample.json
+++ b/tests/e2e/fixtures/real-scan-sample.json
@@ -1,0 +1,179 @@
+{
+  "_comment": "Real scan results captured from the live extension (gpdtest734@gmail.com). Used as reference for test fixture shapes.",
+  "_source": "CDP capture via tools/cdp.py from live Google Photos session",
+  "_captured": "2026-04-16",
+  "accountEmail": "gpdtest734@gmail.com",
+  "groups": [
+    {
+      "id": "group-8",
+      "mediaKeys": [
+        "AF1QipM-SNgePsOxxic2g2J-dRTpzCuM3MFfPwOXCPxd",
+        "AF1QipMqZ4kBDJHkzkzHxkhAjhTCrDYG3u13c_eq_i1j"
+      ],
+      "originalMediaKey": "AF1QipM-SNgePsOxxic2g2J-dRTpzCuM3MFfPwOXCPxd",
+      "similarity": 0.9
+    },
+    {
+      "id": "group-9",
+      "mediaKeys": [
+        "AF1QipOwTNmDKpG9A3iGWCmck653gzLuCG_kRJt2N2bj",
+        "AF1QipM-aQ0K9ejbjaXHfAZdHkwOd5Ss-TunGh0EJ_p1"
+      ],
+      "originalMediaKey": "AF1QipOwTNmDKpG9A3iGWCmck653gzLuCG_kRJt2N2bj",
+      "similarity": 0.9
+    },
+    {
+      "id": "group-10",
+      "mediaKeys": [
+        "AF1QipM0H3dTZP0Q7OUBPQ2sAmIkQar4B_sxShq5MI4D",
+        "AF1QipM2Kdxi9WbVHvRLLwcHdCFWBTvUfDLYf2J42Zxv"
+      ],
+      "originalMediaKey": "AF1QipM0H3dTZP0Q7OUBPQ2sAmIkQar4B_sxShq5MI4D",
+      "similarity": 0.9
+    },
+    {
+      "id": "group-11",
+      "mediaKeys": [
+        "AF1QipNS0DjcANJ3SPYs4Ec-E5AO-K3-7sRpFPpDGVgV",
+        "AF1QipM26kCpJq1ZaSJTmRXxbrPhuH4LIqksIat09I4V"
+      ],
+      "originalMediaKey": "AF1QipNS0DjcANJ3SPYs4Ec-E5AO-K3-7sRpFPpDGVgV",
+      "similarity": 0.9
+    },
+    {
+      "id": "group-12",
+      "mediaKeys": [
+        "AF1QipMM0AazOW2KbZtSi4t1uysoa1wPJYNgzq9fQ8md",
+        "AF1QipM2GyJD4xERuHZKh0QpvCU_bV-M-U30Cfoa-iM5"
+      ],
+      "originalMediaKey": "AF1QipMM0AazOW2KbZtSi4t1uysoa1wPJYNgzq9fQ8md",
+      "similarity": 0.9
+    }
+  ],
+  "mediaItems": {
+    "AF1QipM-SNgePsOxxic2g2J-dRTpzCuM3MFfPwOXCPxd": {
+      "creationTimestamp": 1689426093813,
+      "dedupKey": "RS_zn94LIMvcF5NUVvJtOx800cs",
+      "fileName": null,
+      "isOwned": true,
+      "mediaKey": "AF1QipM-SNgePsOxxic2g2J-dRTpzCuM3MFfPwOXCPxd",
+      "productUrl": "https://photos.google.com/photo/AF1QipM-SNgePsOxxic2g2J-dRTpzCuM3MFfPwOXCPxd",
+      "resHeight": 1440,
+      "resWidth": 2560,
+      "thumb": "https://photos.fife.usercontent.google.com/pw/AP1GczPBjx1x2XRuaqHtt3KWpwpfH3lzYZcaotj0Sns3wLbVBm1bUs54soZS",
+      "timestamp": 1370474434000
+    },
+    "AF1QipM-aQ0K9ejbjaXHfAZdHkwOd5Ss-TunGh0EJ_p1": {
+      "creationTimestamp": 1691328837343,
+      "dedupKey": "wVm-zjQKWeNJurORpb2wqxGxXx8",
+      "fileName": null,
+      "isOwned": true,
+      "mediaKey": "AF1QipM-aQ0K9ejbjaXHfAZdHkwOd5Ss-TunGh0EJ_p1",
+      "productUrl": "https://photos.google.com/photo/AF1QipM-aQ0K9ejbjaXHfAZdHkwOd5Ss-TunGh0EJ_p1",
+      "resHeight": 3920,
+      "resWidth": 4080,
+      "thumb": "https://photos.fife.usercontent.google.com/pw/AP1GczNmrh53AKsJI88yNMf0-xKqXUfkcbD_1WRfxqOM_X8cqChIU_qhGexX",
+      "timestamp": 1295467200000
+    },
+    "AF1QipM0H3dTZP0Q7OUBPQ2sAmIkQar4B_sxShq5MI4D": {
+      "creationTimestamp": 1689425993144,
+      "dedupKey": "DZe8Nbd1tOSUhdMGLBwyemO-T4k",
+      "fileName": null,
+      "isOwned": true,
+      "mediaKey": "AF1QipM0H3dTZP0Q7OUBPQ2sAmIkQar4B_sxShq5MI4D",
+      "productUrl": "https://photos.google.com/photo/AF1QipM0H3dTZP0Q7OUBPQ2sAmIkQar4B_sxShq5MI4D",
+      "resHeight": 1080,
+      "resWidth": 1920,
+      "thumb": "https://photos.fife.usercontent.google.com/pw/AP1GczP3_fn0veiIY-YtUaud-9Pb9z3l60w6ZOP34pqdOEXu_APFYRv5HcQI",
+      "timestamp": 1301028620000
+    },
+    "AF1QipM26kCpJq1ZaSJTmRXxbrPhuH4LIqksIat09I4V": {
+      "creationTimestamp": 1691328864448,
+      "dedupKey": "wvDLI4SgwMtmeZxclFVZxhe7GuA",
+      "fileName": null,
+      "isOwned": true,
+      "mediaKey": "AF1QipM26kCpJq1ZaSJTmRXxbrPhuH4LIqksIat09I4V",
+      "productUrl": "https://photos.google.com/photo/AF1QipM26kCpJq1ZaSJTmRXxbrPhuH4LIqksIat09I4V",
+      "resHeight": 1080,
+      "resWidth": 1920,
+      "thumb": "https://photos.fife.usercontent.google.com/pw/AP1GczM5I7pnikGWCFHEy4mYayW2Eoo-2f7HyXx9TL9grZ9f-YLVOsEbzrCf",
+      "timestamp": 1691328814324
+    },
+    "AF1QipM2GyJD4xERuHZKh0QpvCU_bV-M-U30Cfoa-iM5": {
+      "creationTimestamp": 1691328836333,
+      "dedupKey": "rEuFsI6-hfD-NAmrQ-f_18idvA8",
+      "fileName": null,
+      "isOwned": true,
+      "mediaKey": "AF1QipM2GyJD4xERuHZKh0QpvCU_bV-M-U30Cfoa-iM5",
+      "productUrl": "https://photos.google.com/photo/AF1QipM2GyJD4xERuHZKh0QpvCU_bV-M-U30Cfoa-iM5",
+      "resHeight": 1600,
+      "resWidth": 2560,
+      "thumb": "https://photos.fife.usercontent.google.com/pw/AP1GczNXZOym2BouEiZlvMHXCRIVs2cOujB-yytm5RCx8QP_uI3fjgEEO710",
+      "timestamp": 1172953479000
+    },
+    "AF1QipM2Kdxi9WbVHvRLLwcHdCFWBTvUfDLYf2J42Zxv": {
+      "creationTimestamp": 1691328835482,
+      "dedupKey": "xhjktOst0RSksb0ycIqmw8lUoYE",
+      "fileName": null,
+      "isOwned": true,
+      "mediaKey": "AF1QipM2Kdxi9WbVHvRLLwcHdCFWBTvUfDLYf2J42Zxv",
+      "productUrl": "https://photos.google.com/photo/AF1QipM2Kdxi9WbVHvRLLwcHdCFWBTvUfDLYf2J42Zxv",
+      "resHeight": 1080,
+      "resWidth": 1920,
+      "thumb": "https://photos.fife.usercontent.google.com/pw/AP1GczPdTTlf8qdfsNn-MawlL_9sGeLo6th9xXN0_Po5tAaPuASqejU42_ua",
+      "timestamp": 1301028620000
+    },
+    "AF1QipMM0AazOW2KbZtSi4t1uysoa1wPJYNgzq9fQ8md": {
+      "creationTimestamp": 1689426076015,
+      "dedupKey": "TLcD5eIHSUOI8Ckn6Jv445PDMAs",
+      "fileName": null,
+      "isOwned": true,
+      "mediaKey": "AF1QipMM0AazOW2KbZtSi4t1uysoa1wPJYNgzq9fQ8md",
+      "productUrl": "https://photos.google.com/photo/AF1QipMM0AazOW2KbZtSi4t1uysoa1wPJYNgzq9fQ8md",
+      "resHeight": 1600,
+      "resWidth": 2560,
+      "thumb": "https://photos.fife.usercontent.google.com/pw/AP1GczPcTF7agPvAsLKJaeBdD3bKtyLktyc8Pkh8hryYWaQjQwUOGn-S9J23",
+      "timestamp": 1172953479000
+    },
+    "AF1QipMqZ4kBDJHkzkzHxkhAjhTCrDYG3u13c_eq_i1j": {
+      "creationTimestamp": 1691328850909,
+      "dedupKey": "hJx3AYqsztaPsBsw8iJnuF-b0aU",
+      "fileName": null,
+      "isOwned": true,
+      "mediaKey": "AF1QipMqZ4kBDJHkzkzHxkhAjhTCrDYG3u13c_eq_i1j",
+      "productUrl": "https://photos.google.com/photo/AF1QipMqZ4kBDJHkzkzHxkhAjhTCrDYG3u13c_eq_i1j",
+      "resHeight": 1440,
+      "resWidth": 2560,
+      "thumb": "https://photos.fife.usercontent.google.com/pw/AP1GczN6esegboDs0VyIUy6k434Xjyzum2VhqD-Lep5Fu6ESioJOQydABDs5",
+      "timestamp": 1370474434000
+    },
+    "AF1QipNS0DjcANJ3SPYs4Ec-E5AO-K3-7sRpFPpDGVgV": {
+      "creationTimestamp": 1689426104410,
+      "dedupKey": "shmw4nVw2xUKMlDmsxhfN38BfKw",
+      "fileName": null,
+      "isOwned": true,
+      "mediaKey": "AF1QipNS0DjcANJ3SPYs4Ec-E5AO-K3-7sRpFPpDGVgV",
+      "productUrl": "https://photos.google.com/photo/AF1QipNS0DjcANJ3SPYs4Ec-E5AO-K3-7sRpFPpDGVgV",
+      "resHeight": 1080,
+      "resWidth": 1920,
+      "thumb": "https://photos.fife.usercontent.google.com/pw/AP1GczNLK4AWAhMHQjN5Dbiy0OBGvPrN7tdpg4vxMh9c64gCXzSJZJ_O5EZ2",
+      "timestamp": 1447724257000
+    },
+    "AF1QipOwTNmDKpG9A3iGWCmck653gzLuCG_kRJt2N2bj": {
+      "creationTimestamp": 1689426128189,
+      "dedupKey": "e6YGhhTqy3LS77X9_8YsYn934hs",
+      "fileName": null,
+      "isOwned": true,
+      "mediaKey": "AF1QipOwTNmDKpG9A3iGWCmck653gzLuCG_kRJt2N2bj",
+      "productUrl": "https://photos.google.com/photo/AF1QipOwTNmDKpG9A3iGWCmck653gzLuCG_kRJt2N2bj",
+      "resHeight": 3920,
+      "resWidth": 4080,
+      "thumb": "https://photos.fife.usercontent.google.com/pw/AP1GczNx7cCXKKgAj_GxcMMjZ7BAI9DLdcBk4z-t5h2snygpM2CHaUJUxMpQ",
+      "timestamp": 1295467200000
+    }
+  },
+  "settings": {
+    "scanMode": "full",
+    "similarityThreshold": 0.9
+  }
+}

--- a/tests/e2e/integration/cross-tab-messaging.test.ts
+++ b/tests/e2e/integration/cross-tab-messaging.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Cross-tab messaging integration tests.
+ *
+ * Exercises the complete three-context messaging loop using a real Playwright-
+ * launched extension and a GPTK stub page that intercepts https://photos.google.com/:
+ *
+ *   App Tab → chrome.runtime.sendMessage
+ *     → Service Worker → chrome.tabs.sendMessage
+ *       → Bridge content script → window.postMessage
+ *         → GPTK stub (replies via window.postMessage)
+ *       → Bridge content script → chrome.runtime.sendMessage
+ *     → Service Worker → chrome.tabs.sendMessage
+ *   → App Tab (receives result)
+ *
+ * No Google Photos auth required. Run via: npm run test:integration
+ *
+ * Prerequisites: `npm run dev` (dev build) or `npm run build` (prod build)
+ */
+import { test, expect, type BrowserContext, type Page } from "@playwright/test"
+import {
+  launchExtension,
+  openAppTab,
+  openGptkStubPage,
+  clearStorage,
+} from "../fixtures/extension"
+
+let context: BrowserContext
+let extensionId: string
+
+test.beforeAll(async () => {
+  ;({ context, extensionId } = await launchExtension())
+})
+
+test.afterAll(async () => {
+  await context.close()
+})
+
+// ============================================================
+// Helpers
+// ============================================================
+
+/** Send a chrome.runtime message from the app tab and return the response. */
+async function sendAppMessage(
+  appPage: Page,
+  message: Record<string, unknown>
+): Promise<unknown> {
+  return appPage.evaluate((msg) => {
+    return new Promise((resolve) => {
+      chrome.runtime.sendMessage(msg, resolve)
+    })
+  }, message)
+}
+
+// ============================================================
+// healthCheck flow
+// ============================================================
+
+test.describe("healthCheck", () => {
+  test("app tab receives healthCheck.result success when GP stub responds", async () => {
+    await clearStorage(context)
+
+    // Open stub first so the service worker finds it when healthCheck fires
+    const stub = await openGptkStubPage(context)
+    const page = await openAppTab(context, extensionId)
+
+    // The app tab fires healthCheck on mount — wait for connected state
+    await expect(
+      page.getByRole("button", { name: /Scan Library/i })
+    ).toBeVisible({ timeout: 10_000 })
+
+    await stub.close()
+    await page.close()
+  })
+
+  test("app tab shows disconnected when GP tab is not open", async () => {
+    await clearStorage(context)
+
+    // Open app tab without any GP stub — healthCheck should fail
+    const page = await openAppTab(context, extensionId)
+
+    await expect(
+      page.getByText(/Cannot connect to Google Photos/i)
+    ).toBeVisible({ timeout: 10_000 })
+
+    await page.close()
+  })
+
+  test("app tab reflects the accountEmail returned by the stub", async () => {
+    await clearStorage(context)
+
+    const stub = await openGptkStubPage(context, {
+      healthCheck: {
+        data: {
+          hasGptk: true,
+          hasWizData: true,
+          accountEmail: "custom@example.com",
+        },
+      } as never,
+    })
+    const page = await openAppTab(context, extensionId)
+
+    // Connected state means the healthCheck round-trip succeeded
+    await expect(
+      page.getByRole("button", { name: /Scan Library/i })
+    ).toBeVisible({ timeout: 10_000 })
+
+    await stub.close()
+    await page.close()
+  })
+})
+
+// ============================================================
+// GP tab close notification
+// ============================================================
+
+test.describe("tab lifecycle", () => {
+  test("app tab receives GP_TAB_CLOSED when GP stub tab is closed", async () => {
+    await clearStorage(context)
+
+    const stub = await openGptkStubPage(context)
+    const page = await openAppTab(context, extensionId)
+
+    // Wait for connected state
+    await expect(
+      page.getByRole("button", { name: /Scan Library/i })
+    ).toBeVisible({ timeout: 10_000 })
+
+    // Close the GP stub tab
+    await stub.close()
+
+    // App should now show disconnected (GP_TAB_CLOSED event)
+    await expect(
+      page.getByText(/Google Photos tab was closed|Cannot connect/i)
+    ).toBeVisible({ timeout: 10_000 })
+
+    await page.close()
+  })
+})
+
+// ============================================================
+// gptkCommand routing — direct round-trip
+// ============================================================
+
+test.describe("gptkCommand routing", () => {
+  test("app tab receives gptkResult after command is relayed through GP stub", async () => {
+    await clearStorage(context)
+
+    const stub = await openGptkStubPage(context)
+    const page = await openAppTab(context, extensionId)
+
+    // Wait for connected state (proves the tab mapping is established)
+    await expect(
+      page.getByRole("button", { name: /Scan Library/i })
+    ).toBeVisible({ timeout: 10_000 })
+
+    // Send a gptkCommand from the app tab and capture the result via a listener
+    const result = await page.evaluate(() => {
+      return new Promise<{
+        success: boolean
+        command: string
+        data: unknown
+      }>((resolve) => {
+        const APP_ID = "GPD"
+        const requestId = `test-${Date.now()}`
+
+        const listener = (msg: Record<string, unknown>) => {
+          if (
+            msg?.app === APP_ID &&
+            msg?.action === "gptkResult" &&
+            msg?.requestId === requestId
+          ) {
+            chrome.runtime.onMessage.removeListener(listener)
+            resolve({
+              success: msg.success as boolean,
+              command: msg.command as string,
+              data: msg.data,
+            })
+          }
+        }
+        chrome.runtime.onMessage.addListener(listener)
+
+        chrome.runtime.sendMessage({
+          app: APP_ID,
+          action: "gptkCommand",
+          command: "healthCheck",
+          requestId,
+        })
+      })
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.command).toBe("healthCheck")
+    expect((result.data as Record<string, unknown>)?.hasGptk).toBe(true)
+
+    await stub.close()
+    await page.close()
+  })
+
+  test("app tab receives gptkResult failure when GP tab is not found", async () => {
+    await clearStorage(context)
+
+    // No stub open — service worker cannot route the command
+    const page = await openAppTab(context, extensionId)
+
+    // Wait for disconnected state
+    await expect(
+      page.getByText(/Cannot connect to Google Photos/i)
+    ).toBeVisible({ timeout: 8_000 })
+
+    const result = await page.evaluate(() => {
+      return new Promise<{ success: boolean; error?: string }>((resolve) => {
+        const APP_ID = "GPD"
+        const requestId = `test-nophoto-${Date.now()}`
+
+        const listener = (msg: Record<string, unknown>) => {
+          if (
+            msg?.app === APP_ID &&
+            msg?.action === "gptkResult" &&
+            msg?.requestId === requestId
+          ) {
+            chrome.runtime.onMessage.removeListener(listener)
+            resolve({ success: msg.success as boolean, error: msg.error as string })
+          }
+        }
+        chrome.runtime.onMessage.addListener(listener)
+
+        chrome.runtime.sendMessage({
+          app: APP_ID,
+          action: "gptkCommand",
+          command: "healthCheck",
+          requestId,
+        })
+      })
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeTruthy()
+
+    await page.close()
+  })
+})
+
+// ============================================================
+// Progress streaming
+// ============================================================
+
+test.describe("progress streaming", () => {
+  test("app tab receives intermediate gptkProgress messages during long command", async () => {
+    await clearStorage(context)
+
+    const stub = await openGptkStubPage(context)
+    const page = await openAppTab(context, extensionId)
+
+    await expect(
+      page.getByRole("button", { name: /Scan Library/i })
+    ).toBeVisible({ timeout: 10_000 })
+
+    // Trigger a trashItems command with 600 items (2 batches of 250 + 100)
+    // The stub emits progress after each batch, so we expect at least one progress event.
+    const progressEvents = await page.evaluate(() => {
+      return new Promise<number[]>((resolve) => {
+        const APP_ID = "GPD"
+        const requestId = `test-progress-${Date.now()}`
+        const events: number[] = []
+
+        const listener = (msg: Record<string, unknown>) => {
+          if (msg?.app !== APP_ID || msg?.requestId !== requestId) return
+          if (msg.action === "gptkProgress") {
+            events.push(msg.itemsProcessed as number)
+          }
+          if (msg.action === "gptkResult") {
+            chrome.runtime.onMessage.removeListener(listener)
+            resolve(events)
+          }
+        }
+        chrome.runtime.onMessage.addListener(listener)
+
+        const dedupKeys = Array.from({ length: 600 }, (_, i) => `key-${i}`)
+        chrome.runtime.sendMessage({
+          app: APP_ID,
+          action: "gptkCommand",
+          command: "trashItems",
+          requestId,
+          args: { dedupKeys },
+        })
+      })
+    })
+
+    // Expect at least 2 progress events (batch 250, batch 500, plus 600)
+    expect(progressEvents.length).toBeGreaterThanOrEqual(2)
+    // Progress values should be non-decreasing
+    for (let i = 1; i < progressEvents.length; i++) {
+      expect(progressEvents[i]).toBeGreaterThanOrEqual(progressEvents[i - 1])
+    }
+    // Final progress should equal total
+    expect(progressEvents.at(-1)).toBe(600)
+
+    await stub.close()
+    await page.close()
+  })
+})

--- a/tests/e2e/integration/trash-undo.test.ts
+++ b/tests/e2e/integration/trash-undo.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Trash & Undo integration tests.
+ *
+ * Covers the app-tab UI layer for the full trash/restore workflow using a real
+ * Playwright-launched extension and the GPTK stub page. No Google auth required.
+ *
+ * The GPTK command layer (chunking, progress) is already unit-tested in
+ * tests/commands/google-photos-commands.test.ts — these tests focus on the
+ * UI integration: button → confirm dialog → progress display → snackbar → undo.
+ *
+ * Run via: npm run test:integration
+ */
+import { test, expect, type BrowserContext } from "@playwright/test"
+import {
+  launchExtension,
+  openAppTab,
+  openGptkStubPage,
+  injectScanResults,
+  clearStorage,
+  makeGroups,
+} from "../fixtures/extension"
+
+let context: BrowserContext
+let extensionId: string
+
+test.beforeAll(async () => {
+  ;({ context, extensionId } = await launchExtension())
+})
+
+test.afterAll(async () => {
+  await context.close()
+})
+
+// ============================================================
+// Test data helpers
+// ============================================================
+
+/**
+ * Standard small dataset: 3 groups × 2 items each → 3 dedupKeys to trash.
+ * Small enough to fit in a single 250-item batch.
+ */
+function smallPayload() {
+  return makeGroups(3, 2)
+}
+
+// ============================================================
+// Trash: baseline (< 250 items, single batch)
+// ============================================================
+
+test("trashes selected groups and removes them from the UI", async () => {
+  await clearStorage(context)
+  const { groups, mediaItems } = smallPayload()
+  await injectScanResults(context, groups, mediaItems, Object.keys(mediaItems).length)
+
+  const stub = await openGptkStubPage(context)
+  const page = await openAppTab(context, extensionId)
+
+  // App should load results from storage (no GP auth needed for results view)
+  await expect(page.getByText("3 Duplicate Groups Found")).toBeVisible({ timeout: 8_000 })
+
+  // Click "Move N Duplicates to Trash" in the ActionBar
+  await page.getByRole("button", { name: /Move \d+ Duplicates? to Trash/i }).click()
+
+  // Confirm dialog appears
+  await expect(page.getByRole("dialog")).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Move to Trash" })).toBeVisible()
+
+  // Confirm
+  await page.getByRole("button", { name: /Move to Trash/i }).last().click()
+
+  // Undo snackbar should appear (trash complete)
+  await expect(
+    page.getByText(/moved to trash/i)
+  ).toBeVisible({ timeout: 10_000 })
+
+  // Groups list should no longer show duplicate groups
+  await expect(page.getByText("3 Duplicate Groups Found")).not.toBeVisible()
+
+  await stub.close()
+  await page.close()
+})
+
+// ============================================================
+// Trash: multi-batch (> 250 items)
+// ============================================================
+
+test("shows trashing state for multi-batch trash (> 250 items)", async () => {
+  await clearStorage(context)
+
+  // 3 groups × 101 items → 303 dedupKeys → 2 batches (250 + 53)
+  const { groups, mediaItems } = makeGroups(3, 101)
+  await injectScanResults(context, groups, mediaItems, Object.keys(mediaItems).length)
+
+  const stub = await openGptkStubPage(context)
+  const page = await openAppTab(context, extensionId)
+
+  await expect(page.getByText("3 Duplicate Groups Found")).toBeVisible({ timeout: 8_000 })
+
+  await page.getByRole("button", { name: /Move \d+ Duplicates? to Trash/i }).click()
+  await expect(page.getByRole("dialog")).toBeVisible()
+  await page.getByRole("button", { name: /Move to Trash/i }).last().click()
+
+  // After all batches complete: undo snackbar appears
+  await expect(
+    page.getByText(/moved to trash/i)
+  ).toBeVisible({ timeout: 15_000 })
+
+  // Groups should be gone
+  await expect(page.getByText("3 Duplicate Groups Found")).not.toBeVisible()
+
+  await stub.close()
+  await page.close()
+})
+
+// ============================================================
+// Undo: baseline restore
+// ============================================================
+
+test("undo restores all groups to the UI", async () => {
+  await clearStorage(context)
+  const { groups, mediaItems } = smallPayload()
+  await injectScanResults(context, groups, mediaItems, Object.keys(mediaItems).length)
+
+  const stub = await openGptkStubPage(context)
+  const page = await openAppTab(context, extensionId)
+
+  await expect(page.getByText("3 Duplicate Groups Found")).toBeVisible({ timeout: 8_000 })
+
+  // Trash all groups
+  await page.getByRole("button", { name: /Move \d+ Duplicates? to Trash/i }).click()
+  await page.getByRole("button", { name: /Move to Trash/i }).last().click()
+  await expect(page.getByText(/moved to trash/i)).toBeVisible({ timeout: 10_000 })
+
+  // Click Undo in the snackbar
+  await page.getByRole("button", { name: /undo/i }).click()
+
+  // All 3 groups should be restored
+  await expect(page.getByText("3 Duplicate Groups Found")).toBeVisible({ timeout: 10_000 })
+
+  // Undo snackbar should be dismissed
+  await expect(page.getByText(/moved to trash/i)).not.toBeVisible()
+
+  await stub.close()
+  await page.close()
+})
+
+// ============================================================
+// Undo: multi-batch restore
+// ============================================================
+
+test("undo after multi-batch trash restores all groups", async () => {
+  await clearStorage(context)
+
+  const { groups, mediaItems } = makeGroups(3, 101) // 303 dedupKeys
+  await injectScanResults(context, groups, mediaItems, Object.keys(mediaItems).length)
+
+  const stub = await openGptkStubPage(context)
+  const page = await openAppTab(context, extensionId)
+
+  await expect(page.getByText("3 Duplicate Groups Found")).toBeVisible({ timeout: 8_000 })
+
+  await page.getByRole("button", { name: /Move \d+ Duplicates? to Trash/i }).click()
+  await page.getByRole("button", { name: /Move to Trash/i }).last().click()
+  await expect(page.getByText(/moved to trash/i)).toBeVisible({ timeout: 15_000 })
+
+  await page.getByRole("button", { name: /undo/i }).click()
+
+  // Pre-trash state fully restored
+  await expect(page.getByText("3 Duplicate Groups Found")).toBeVisible({ timeout: 10_000 })
+
+  await stub.close()
+  await page.close()
+})
+
+// ============================================================
+// Error: trash API failure
+// ============================================================
+
+test("shows error state when trashItems fails", async () => {
+  await clearStorage(context)
+  const { groups, mediaItems } = smallPayload()
+  await injectScanResults(context, groups, mediaItems, Object.keys(mediaItems).length)
+
+  // Configure stub to return failure for trashItems
+  const stub = await openGptkStubPage(context, {
+    trashItems: { success: false, error: "HTTP 504" },
+  })
+  const page = await openAppTab(context, extensionId)
+
+  await expect(page.getByText("3 Duplicate Groups Found")).toBeVisible({ timeout: 8_000 })
+
+  await page.getByRole("button", { name: /Move \d+ Duplicates? to Trash/i }).click()
+  await page.getByRole("button", { name: /Move to Trash/i }).last().click()
+
+  // TRASH_ERROR dispatches { status: "disconnected", error: "HTTP 504" }.
+  // The disconnected state shows the error string in an Alert and a "Retry Connection" button.
+  await expect(
+    page.getByRole("button", { name: /Retry Connection/i })
+  ).toBeVisible({ timeout: 10_000 })
+  // The raw error from the stub is surfaced in the Alert
+  await expect(page.getByText("HTTP 504")).toBeVisible()
+
+  await stub.close()
+  await page.close()
+})
+
+// ============================================================
+// Cancel: dismiss confirm dialog without trashing
+// ============================================================
+
+test("cancel dialog does not trigger trash", async () => {
+  await clearStorage(context)
+  const { groups, mediaItems } = smallPayload()
+  await injectScanResults(context, groups, mediaItems, Object.keys(mediaItems).length)
+
+  const stub = await openGptkStubPage(context)
+  const page = await openAppTab(context, extensionId)
+
+  await expect(page.getByText("3 Duplicate Groups Found")).toBeVisible({ timeout: 8_000 })
+
+  await page.getByRole("button", { name: /Move \d+ Duplicates? to Trash/i }).click()
+  await expect(page.getByRole("dialog")).toBeVisible()
+
+  // Click Cancel in the dialog
+  await page.getByRole("button", { name: /^Cancel$/i }).click()
+
+  // Dialog should close; groups remain intact
+  await expect(page.getByRole("dialog")).not.toBeVisible()
+  await expect(page.getByText("3 Duplicate Groups Found")).toBeVisible()
+  await expect(page.getByText(/moved to trash/i)).not.toBeVisible()
+
+  await stub.close()
+  await page.close()
+})

--- a/tests/lib/embedding-cache.test.ts
+++ b/tests/lib/embedding-cache.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for lib/embedding-cache.ts — EmbeddingCache (IndexedDB wrapper).
+ *
+ * Uses fake-indexeddb (in-memory IDB) for isolation.
+ * Each test gets a fresh IDBFactory instance so state never leaks.
+ *
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, beforeEach } from "vitest"
+import { IDBFactory } from "fake-indexeddb"
+import { EmbeddingCache } from "../../lib/embedding-cache"
+
+// ============================================================
+// Test isolation: fresh IDB store per test
+// ============================================================
+
+beforeEach(() => {
+  // Replace the global indexedDB with a fresh in-memory factory.
+  // EmbeddingCache.open() uses indexedDB as a global, so this
+  // ensures each test starts with an empty database.
+  globalThis.indexedDB = new IDBFactory()
+})
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function makeEmbedding(seed: number, length = 8): Float32Array {
+  return new Float32Array(Array.from({ length }, (_, i) => seed + i * 0.1))
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe("EmbeddingCache", () => {
+  describe("getMany + setMany round-trip", () => {
+    it("returns stored embeddings by mediaKey", async () => {
+      const cache = await EmbeddingCache.open()
+      await cache.setMany([
+        { mediaKey: "key1", embedding: makeEmbedding(1) },
+        { mediaKey: "key2", embedding: makeEmbedding(2) },
+      ])
+
+      const results = await cache.getMany(["key1", "key2"])
+      expect(results).toHaveLength(2)
+      expect(results[0]).toBeInstanceOf(Float32Array)
+      expect(Array.from(results[0]!)).toEqual(Array.from(makeEmbedding(1)))
+      expect(Array.from(results[1]!)).toEqual(Array.from(makeEmbedding(2)))
+      cache.close()
+    })
+
+    it("returns null for cache misses", async () => {
+      const cache = await EmbeddingCache.open()
+      const results = await cache.getMany(["missing-key"])
+      expect(results[0]).toBeNull()
+      cache.close()
+    })
+
+    it("returns mixed hits and misses in correct order", async () => {
+      const cache = await EmbeddingCache.open()
+      await cache.setMany([{ mediaKey: "present", embedding: makeEmbedding(5) }])
+
+      const results = await cache.getMany(["present", "absent", "present"])
+      expect(results[0]).not.toBeNull()
+      expect(results[1]).toBeNull()
+      expect(results[2]).not.toBeNull()
+      cache.close()
+    })
+
+    it("returns empty array for empty input", async () => {
+      const cache = await EmbeddingCache.open()
+      const results = await cache.getMany([])
+      expect(results).toEqual([])
+      cache.close()
+    })
+
+    it("overwrites an existing entry on setMany", async () => {
+      const cache = await EmbeddingCache.open()
+      await cache.setMany([{ mediaKey: "key1", embedding: makeEmbedding(1) }])
+      await cache.setMany([{ mediaKey: "key1", embedding: makeEmbedding(99) }])
+
+      const results = await cache.getMany(["key1"])
+      expect(Array.from(results[0]!)).toEqual(Array.from(makeEmbedding(99)))
+      cache.close()
+    })
+  })
+
+  describe("count", () => {
+    it("returns 0 for an empty cache", async () => {
+      const cache = await EmbeddingCache.open()
+      expect(await cache.count()).toBe(0)
+      cache.close()
+    })
+
+    it("returns the number of stored entries", async () => {
+      const cache = await EmbeddingCache.open()
+      await cache.setMany([
+        { mediaKey: "k1", embedding: makeEmbedding(1) },
+        { mediaKey: "k2", embedding: makeEmbedding(2) },
+        { mediaKey: "k3", embedding: makeEmbedding(3) },
+      ])
+      expect(await cache.count()).toBe(3)
+      cache.close()
+    })
+  })
+
+  describe("evictExcept", () => {
+    it("deletes keys not in the keep set and returns eviction count", async () => {
+      const cache = await EmbeddingCache.open()
+      await cache.setMany([
+        { mediaKey: "keep-me", embedding: makeEmbedding(1) },
+        { mediaKey: "evict-me", embedding: makeEmbedding(2) },
+        { mediaKey: "also-evict", embedding: makeEmbedding(3) },
+      ])
+
+      const evicted = await cache.evictExcept(new Set(["keep-me"]))
+      expect(evicted).toBe(2)
+
+      const remaining = await cache.getMany(["keep-me", "evict-me", "also-evict"])
+      expect(remaining[0]).not.toBeNull()
+      expect(remaining[1]).toBeNull()
+      expect(remaining[2]).toBeNull()
+      cache.close()
+    })
+
+    it("evicts nothing when all keys are in keep set", async () => {
+      const cache = await EmbeddingCache.open()
+      await cache.setMany([
+        { mediaKey: "a", embedding: makeEmbedding(1) },
+        { mediaKey: "b", embedding: makeEmbedding(2) },
+      ])
+
+      const evicted = await cache.evictExcept(new Set(["a", "b"]))
+      expect(evicted).toBe(0)
+      expect(await cache.count()).toBe(2)
+      cache.close()
+    })
+
+    it("evicts all keys when keep set is empty", async () => {
+      const cache = await EmbeddingCache.open()
+      await cache.setMany([
+        { mediaKey: "x", embedding: makeEmbedding(1) },
+        { mediaKey: "y", embedding: makeEmbedding(2) },
+      ])
+
+      const evicted = await cache.evictExcept(new Set())
+      expect(evicted).toBe(2)
+      expect(await cache.count()).toBe(0)
+      cache.close()
+    })
+  })
+})

--- a/tests/lib/scan-log.test.ts
+++ b/tests/lib/scan-log.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Unit tests for lib/scan-log.ts — ScanLogger and StabilityTracker.
+ *
+ * chrome.storage.local is mocked in-memory. Each test gets a fresh store
+ * so state never leaks between tests.
+ *
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { ScanLogger, StabilityTracker } from "../../lib/scan-log"
+
+// ============================================================
+// chrome.storage.local mock
+// ============================================================
+
+let store: Record<string, unknown> = {}
+
+const mockStorage = {
+  get: vi.fn(async (key: string | string[] | null) => {
+    if (key === null) return { ...store }
+    if (typeof key === "string") return { [key]: store[key] }
+    return Object.fromEntries((key as string[]).map((k) => [k, store[k]]))
+  }),
+  set: vi.fn(async (items: Record<string, unknown>) => {
+    Object.assign(store, items)
+  }),
+  remove: vi.fn(async (key: string | string[]) => {
+    const keys = typeof key === "string" ? [key] : key
+    for (const k of keys) delete store[k]
+  }),
+  clear: vi.fn(async () => {
+    store = {}
+  }),
+}
+
+vi.stubGlobal("chrome", { storage: { local: mockStorage } })
+
+beforeEach(() => {
+  store = {}
+  vi.clearAllMocks()
+})
+
+// ============================================================
+// ScanLogger tests
+// ============================================================
+
+describe("ScanLogger", () => {
+  describe("start + finalize", () => {
+    it("writes an active entry to storage on start", async () => {
+      const logger = new ScanLogger()
+      await logger.start(5000)
+
+      expect(mockStorage.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scanLogActive: expect.objectContaining({
+            totalItems: 5000,
+            candidates: 0,
+            cacheHits: 0,
+          }),
+        })
+      )
+    })
+
+    it("commits a log entry and removes active key on finalize", async () => {
+      const logger = new ScanLogger()
+      await logger.start(1000)
+      await logger.finalize("complete", { groupsFound: 42 })
+
+      expect(store["scanLogs"]).toHaveLength(1)
+      const entry = (store["scanLogs"] as unknown[])[0] as Record<string, unknown>
+      expect(entry.status).toBe("complete")
+      expect(entry.groupsFound).toBe(42)
+      expect(entry.totalItems).toBe(1000)
+      expect(store["scanLogActive"]).toBeUndefined()
+    })
+
+    it("sets status to 'error' and records error string on finalize", async () => {
+      const logger = new ScanLogger()
+      await logger.start(200)
+      await logger.finalize("error", { error: "Network timeout" })
+
+      const entry = (store["scanLogs"] as unknown[])[0] as Record<string, unknown>
+      expect(entry.status).toBe("error")
+      expect(entry.error).toBe("Network timeout")
+    })
+
+    it("does not write to storage when finalize is called without start", async () => {
+      const logger = new ScanLogger()
+      await logger.finalize("complete")
+      expect(mockStorage.set).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("updateInfo", () => {
+    it("updates candidates and cacheHits in the active entry", async () => {
+      const logger = new ScanLogger()
+      await logger.start(3000)
+      logger.updateInfo({ candidates: 1200, cacheHits: 800 })
+
+      // updateInfo is fire-and-forget; wait a tick for the microtask
+      await Promise.resolve()
+
+      const lastCall = mockStorage.set.mock.calls.at(-1)?.[0] as Record<string, unknown>
+      const active = lastCall?.["scanLogActive"] as Record<string, unknown>
+      expect(active?.candidates).toBe(1200)
+      expect(active?.cacheHits).toBe(800)
+    })
+
+    it("is a no-op when called before start", () => {
+      const logger = new ScanLogger()
+      logger.updateInfo({ candidates: 5, cacheHits: 3 })
+      expect(mockStorage.set).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("phaseComplete", () => {
+    it("records phase timing in the active entry", async () => {
+      const logger = new ScanLogger()
+      await logger.start(500)
+      await logger.phaseComplete("fetchThumbnailsMs", 1234)
+
+      const lastCall = mockStorage.set.mock.calls.at(-1)?.[0] as Record<string, unknown>
+      const active = lastCall?.["scanLogActive"] as Record<string, unknown>
+      const timings = active?.["phaseTimings"] as Record<string, number>
+      expect(timings?.fetchThumbnailsMs).toBe(1234)
+    })
+  })
+
+  describe("recoverStale", () => {
+    it("commits stale active entry as killed_by_reload if present", async () => {
+      // Seed a stale active entry (simulating a mid-scan page reload)
+      store["scanLogActive"] = {
+        startedAt: Date.now() - 5000,
+        totalItems: 800,
+        candidates: 600,
+        cacheHits: 200,
+        phaseTimings: { fetchThumbnailsMs: 1500 },
+        stableEstimates: [],
+      }
+
+      const logger = new ScanLogger()
+      await logger.recoverStale()
+
+      expect(store["scanLogs"]).toHaveLength(1)
+      const entry = (store["scanLogs"] as unknown[])[0] as Record<string, unknown>
+      expect(entry.status).toBe("killed_by_reload")
+      expect(entry.totalItems).toBe(800)
+    })
+
+    it("is a no-op when no active entry exists", async () => {
+      const logger = new ScanLogger()
+      await logger.recoverStale()
+      expect(store["scanLogs"]).toBeUndefined()
+    })
+  })
+
+  describe("log rotation", () => {
+    it("caps stored entries at 50 (MAX_ENTRIES)", async () => {
+      // Pre-fill 50 entries
+      store["scanLogs"] = Array.from({ length: 50 }, (_, i) => ({
+        timestamp: i,
+        status: "complete",
+        totalItems: i,
+        candidates: 0,
+        cacheHits: 0,
+        phaseTimings: {},
+        totalMs: 100,
+        stableEstimates: [],
+      }))
+
+      const logger = new ScanLogger()
+      await logger.start(999)
+      await logger.finalize("complete")
+
+      const logs = store["scanLogs"] as unknown[]
+      expect(logs).toHaveLength(50)
+      // The newest entry should be at the end
+      const last = logs[49] as Record<string, unknown>
+      expect(last.totalItems).toBe(999)
+    })
+  })
+
+  describe("recordStableEstimate", () => {
+    it("appends stable estimates to the active entry", async () => {
+      const logger = new ScanLogger()
+      await logger.start(1000)
+      logger.recordStableEstimate({
+        phase: "computing_embeddings",
+        estimatedMs: 30000,
+        atPercent: 15,
+      })
+
+      await Promise.resolve()
+
+      const lastCall = mockStorage.set.mock.calls.at(-1)?.[0] as Record<string, unknown>
+      const active = lastCall?.["scanLogActive"] as Record<string, unknown>
+      const estimates = active?.["stableEstimates"] as unknown[]
+      expect(estimates).toHaveLength(1)
+      expect(estimates[0]).toMatchObject({ phase: "computing_embeddings", atPercent: 15 })
+    })
+  })
+})
+
+// ============================================================
+// StabilityTracker tests
+// ============================================================
+
+describe("StabilityTracker", () => {
+  // Mock performance.now() to return controlled timestamps so estimates
+  // converge deterministically regardless of actual test execution speed.
+  // The tracker uses elapsedMs = performance.now() - phaseStart to project
+  // total phase duration. We return linearly increasing values so all three
+  // window samples produce the same projected total (~1000ms).
+  let perfNow: ReturnType<typeof vi.spyOn>
+  // Call counter used to control return values across multiple calls
+  let nowCallIndex: number
+
+  beforeEach(() => {
+    nowCallIndex = 0
+    perfNow = vi.spyOn(performance, "now").mockImplementation(() => {
+      // Pattern: phaseStart call → 0, then elapsedMs calls → progress*1000
+      // This makes each window sample = elapsed/progress = 1000ms (all equal)
+      const schedule = [0, 110, 220, 330, 440, 550, 660, 770]
+      return schedule[nowCallIndex++ % schedule.length] ?? 0
+    })
+  })
+
+  afterEach(() => {
+    perfNow.mockRestore()
+  })
+
+  it("fires onStable when three consecutive estimates converge", () => {
+    const onStable = vi.fn()
+    const tracker = new StabilityTracker(onStable, 3, 0.05, 0.1)
+
+    // Call 1: phaseStart = 0, elapsedMs = 110 → 110/0.11 = 1000
+    // Call 2: elapsedMs = 220 → 220/0.22 = 1000
+    // Call 3: elapsedMs = 330 → 330/0.33 = 1000
+    // Window = [1000, 1000, 1000] → max/min = 1.0 ≤ 1.05 → stable
+    tracker.update("computing_embeddings", 110, 1000)
+    tracker.update("computing_embeddings", 220, 1000)
+    tracker.update("computing_embeddings", 330, 1000)
+
+    expect(onStable).toHaveBeenCalledTimes(1)
+    const est = onStable.mock.calls[0][0]
+    expect(est.phase).toBe("computing_embeddings")
+    expect(est.estimatedMs).toBe(1000)
+    expect(est.atPercent).toBe(33)
+  })
+
+  it("does not fire before minProgress threshold", () => {
+    const onStable = vi.fn()
+    const tracker = new StabilityTracker(onStable, 3, 0.05, 0.1)
+
+    // Only 5% progress — below the 10% default minProgress
+    tracker.update("fetching", 5, 100)
+    tracker.update("fetching", 5, 100)
+    tracker.update("fetching", 5, 100)
+
+    expect(onStable).not.toHaveBeenCalled()
+  })
+
+  it("fires onStable at most once per phase", () => {
+    const onStable = vi.fn()
+    const tracker = new StabilityTracker(onStable, 3, 0.05, 0.1)
+
+    // Fill window → fires once on the 3rd call
+    tracker.update("p1", 110, 1000)
+    tracker.update("p1", 220, 1000)
+    tracker.update("p1", 330, 1000)
+    // 4th and 5th calls return early (firedPhases.has("p1")); no extra fires
+    tracker.update("p1", 440, 1000)
+    tracker.update("p1", 550, 1000)
+
+    expect(onStable).toHaveBeenCalledTimes(1)
+  })
+
+  it("resets window on phase transition", () => {
+    const onStable = vi.fn()
+    const tracker = new StabilityTracker(onStable, 3, 0.05, 0.1)
+
+    // phase-a: 2 samples — window incomplete (length 2 < 3), returns early
+    tracker.update("phase-a", 110, 1000)
+    tracker.update("phase-a", 220, 1000)
+    // phase-b: window resets, 3 samples fill it → fires
+    tracker.update("phase-b", 110, 1000)
+    tracker.update("phase-b", 220, 1000)
+    tracker.update("phase-b", 330, 1000)
+
+    // phase-a never completed its window; only phase-b fired
+    expect(onStable).toHaveBeenCalledTimes(1)
+    expect(onStable.mock.calls[0][0].phase).toBe("phase-b")
+  })
+
+  it("is a no-op when total is 0", () => {
+    const onStable = vi.fn()
+    const tracker = new StabilityTracker(onStable)
+    tracker.update("fetching", 10, 0)
+    expect(onStable).not.toHaveBeenCalled()
+  })
+})

--- a/tests/lib/scan-results.test.ts
+++ b/tests/lib/scan-results.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Unit tests for lib/scan-results.ts — areScanResultsValid().
+ *
+ * This function is exercised indirectly by app-reducer.test.ts but
+ * a direct test makes the invalidation contract explicit and catches
+ * future condition additions without relying on reducer state boilerplate.
+ */
+import { describe, it, expect } from "vitest"
+import { areScanResultsValid } from "../../lib/scan-results"
+
+describe("areScanResultsValid", () => {
+  it("returns true when both account emails match", () => {
+    expect(
+      areScanResultsValid(
+        { accountEmail: "user@example.com" },
+        { accountEmail: "user@example.com" }
+      )
+    ).toBe(true)
+  })
+
+  it("returns false when account emails differ", () => {
+    expect(
+      areScanResultsValid(
+        { accountEmail: "alice@example.com" },
+        { accountEmail: "bob@example.com" }
+      )
+    ).toBe(false)
+  })
+
+  it("returns true when stored email is undefined (legacy results without email)", () => {
+    expect(
+      areScanResultsValid(
+        { accountEmail: undefined },
+        { accountEmail: "user@example.com" }
+      )
+    ).toBe(true)
+  })
+
+  it("returns true when context email is undefined (health check did not return email)", () => {
+    expect(
+      areScanResultsValid(
+        { accountEmail: "user@example.com" },
+        { accountEmail: undefined }
+      )
+    ).toBe(true)
+  })
+
+  it("returns true when both emails are undefined", () => {
+    expect(
+      areScanResultsValid(
+        { accountEmail: undefined },
+        { accountEmail: undefined }
+      )
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
Implements QA & test coverage plan: All 166 unit tests and 18 integration tests pass (including 4 existing suites, 184 total).

## What's new

### Unit tests (Vitest)

| File | Coverage |
|------|----------|
| `tests/lib/scan-results.test.ts` | `areScanResultsValid()` — both emails match, differ, one/both undefined |
| `tests/lib/embedding-cache.test.ts` | `getMany`/`setMany` round-trip, cache misses, overwrites, `count`, `evictExcept`; uses `fake-indexeddb` for per-test IDB isolation |
| `tests/lib/scan-log.test.ts` | `ScanLogger` lifecycle (start → updateInfo → phaseComplete → finalize → recoverStale, log rotation); `StabilityTracker` convergence, minProgress guard, fires-once-per-phase, phase reset |
| `tests/components/action-bar.test.tsx` | Stats display, button visibility when `groupCount === 0`, trash button disabled state, all 4 callbacks |
| `tests/components/scan-progress.test.tsx` | All 5 phase labels + step numbers, determinate vs. indeterminate progress, item count captions, cancel button |

### Integration tests (Playwright)

| File | Coverage |
|------|----------|
| `tests/e2e/integration/cross-tab-messaging.test.ts` | Exercises the full 3-context loop (app tab → service worker → GP stub → back): healthCheck success/failure, `accountEmail` propagation, `GP_TAB_CLOSED` when stub tab closes, `gptkCommand` routing, `gptkResult` failure when no GP tab, progress streaming with ≥2 intermediate events |
| `tests/e2e/integration/trash-undo.test.ts` | Small trash (single batch), multi-batch trash (303 items / 2×250 batches), undo restore, undo after multi-batch, API failure → disconnected state, cancel dialog leaves groups intact |

### New fixtures

- **`tests/e2e/fixtures/gptk-stub.html`** — Stub Google Photos page served via `context.route('https://photos.google.com/**', ...)`. Handles `healthCheck`, `getAllMediaItems`, `trashItems` (emits per-chunk `gptkProgress`), `restoreItems`, and per-command failure overrides via `window.__gptkOverrides`.
- **`tests/e2e/fixtures/extension.ts`** — New helpers: `openGptkStubPage()`, `waitForAppState()`, `makeGroups()`
- **`tests/e2e/fixtures/real-scan-sample.json`** — Real `GpdMediaItem` and `DuplicateGroup` shapes captured from the live extension via CDP (used as shape reference, not as runtime fixture data)

## Test run

```
npm test          → 166 passed (12 files)
npm run test:integration  → 18 passed (13.7s)
```