### PR TITLE
Smarter default keep selection

### DIFF
--- a/lib/duplicate-detector.ts
+++ b/lib/duplicate-detector.ts
@@ -10,6 +10,25 @@ import type { GpdMediaItem, DuplicateGroup } from "./types";
 import { StabilityTracker } from "./scan-log";
 import type { ScanLogger } from "./scan-log";
 
+/**
+ * Select the best item to keep from a duplicate group.
+ * Priority: original quality > higher resolution > oldest upload date.
+ */
+export function selectDefaultKeep(items: GpdMediaItem[]): string {
+  const qualityScore = (x: GpdMediaItem) =>
+    x.isOriginalQuality === true ? 2 : x.isOriginalQuality === false ? 0 : 1;
+  const best = [...items].sort((a, b) => {
+    const qDiff = qualityScore(b) - qualityScore(a);
+    if (qDiff !== 0) return qDiff;
+    const pxDiff =
+      (b.resWidth ?? 0) * (b.resHeight ?? 0) -
+      (a.resWidth ?? 0) * (a.resHeight ?? 0);
+    if (pxDiff !== 0) return pxDiff;
+    return (a.creationTimestamp ?? 0) - (b.creationTimestamp ?? 0);
+  });
+  return best[0].mediaKey;
+}
+
 const MODEL_URL =
   "https://storage.googleapis.com/mediapipe-models/image_embedder/mobilenet_v3_large/float32/latest/mobilenet_v3_large.tflite";
 
@@ -270,7 +289,7 @@ export async function fullDetectDuplicates(
     return {
       id: `group-${i}`,
       mediaKeys,
-      originalMediaKey: mediaKeys[0], // Oldest upload date selected as default original
+      originalMediaKey: selectDefaultKeep(items),
       similarity: threshold, // Approximate; all items are at least this similar
     };
   });
@@ -369,7 +388,7 @@ export function withinGroupDuplicates(
       return {
         id: `group-${groupIdOffset + i}`,
         mediaKeys: sorted.map((x) => x.mediaKey),
-        originalMediaKey: sorted[0].mediaKey,
+        originalMediaKey: selectDefaultKeep(items),
         similarity: threshold,
       };
     });
@@ -563,7 +582,7 @@ export async function smartDetectDuplicates(
     return {
       id: `group-${i}`,
       mediaKeys: items.map((x) => x.mediaKey),
-      originalMediaKey: items[0].mediaKey,
+      originalMediaKey: selectDefaultKeep(items),
       similarity: threshold,
     };
   });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -164,6 +164,7 @@ export interface GpdMediaItem {
   fileName?: string;
   size?: number;
   isOwned?: boolean;
+  isOriginalQuality?: boolean | null;
   duration?: number; // video duration (undefined for photos)
 }
 

--- a/scripts/google-photos-commands.js
+++ b/scripts/google-photos-commands.js
@@ -104,6 +104,7 @@ async function getAllMediaItems(requestId, args) {
             resHeight: item.resHeight,
             duration: item.duration,
             isOwned: item.isOwned,
+            isOriginalQuality: item.isOriginalQuality ?? null,
             fileName: item.descriptionShort || null,
             productUrl: "https://photos.google.com/photo/" + item.mediaKey
           })

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -31,6 +31,7 @@ import {
   smartDetectDuplicates
 } from "../lib/duplicate-detector"
 import type { DetectionProgress } from "../lib/duplicate-detector"
+import { selectDefaultKeep } from "../lib/duplicate-detector"
 import { ScanLogger } from "../lib/scan-log"
 import theme from "../lib/theme"
 import { APP_ID, DEFAULT_SETTINGS } from "../lib/types"
@@ -149,48 +150,6 @@ export default function App() {
       setKeptOverrides({})
     }
   }, [groups])
-
-  const getKept = useCallback(
-    (group: DuplicateGroup): Set<string> =>
-      keptOverrides[group.id] ?? new Set([group.originalMediaKey]),
-    [keptOverrides]
-  )
-
-  // Stable default kept sets (one per group, only changes when groups identity changes)
-  const defaultKeptSets = useMemo(() => {
-    const m = new Map<string, Set<string>>()
-    for (const g of groups) m.set(g.id, new Set([g.originalMediaKey]))
-    return m
-  }, [groups])
-
-  // Per-group kept sets: overridden groups use the live override Set (changes only for
-  // the toggled group); unoverridden groups reuse the stable default Set from above so
-  // React.memo on DuplicateGroupRow skips re-renders for unaffected rows.
-  const keptByGroupId = useMemo(() => {
-    const m = new Map<string, Set<string>>()
-    for (const g of groups) {
-      m.set(g.id, keptOverrides[g.id] ?? defaultKeptSets.get(g.id)!)
-    }
-    return m
-  }, [groups, keptOverrides, defaultKeptSets])
-
-  const handleToggleKept = useCallback(
-    (group: DuplicateGroup, mediaKey: string) => {
-      setKeptOverrides((prev) => {
-        const current = prev[group.id] ?? new Set([group.originalMediaKey])
-        // Prevent removing the last kept item
-        if (current.has(mediaKey) && current.size === 1) return prev
-        const next = new Set(current)
-        if (next.has(mediaKey)) {
-          next.delete(mediaKey)
-        } else {
-          next.add(mediaKey)
-        }
-        return { ...prev, [group.id]: next }
-      })
-    },
-    []
-  )
 
   const handleToggleGroup = useCallback((groupId: string) => {
     setSelectedGroupIds((prev) => {
@@ -441,6 +400,56 @@ export default function App() {
 
   // Persist scan results when they change (after scan or trash)
   const mediaItems = state.status === "results" ? state.mediaItems : null
+
+  // Stable default kept sets (one per group, only changes when groups or mediaItems change).
+  // Uses smart keep selection: original quality > higher resolution > oldest upload date.
+  const defaultKeptSets = useMemo(() => {
+    const m = new Map<string, Set<string>>()
+    for (const g of groups) {
+      const groupItems = mediaItems
+        ? g.mediaKeys.map((k) => mediaItems[k]).filter(Boolean)
+        : []
+      const defaultKey =
+        groupItems.length > 0 ? selectDefaultKeep(groupItems) : g.originalMediaKey
+      m.set(g.id, new Set([defaultKey]))
+    }
+    return m
+  }, [groups, mediaItems])
+
+  const getKept = useCallback(
+    (group: DuplicateGroup): Set<string> =>
+      keptOverrides[group.id] ?? defaultKeptSets.get(group.id) ?? new Set([group.originalMediaKey]),
+    [keptOverrides, defaultKeptSets]
+  )
+
+  // Per-group kept sets: overridden groups use the live override Set (changes only for
+  // the toggled group); unoverridden groups reuse the stable default Set from above so
+  // React.memo on DuplicateGroupRow skips re-renders for unaffected rows.
+  const keptByGroupId = useMemo(() => {
+    const m = new Map<string, Set<string>>()
+    for (const g of groups) {
+      m.set(g.id, keptOverrides[g.id] ?? defaultKeptSets.get(g.id)!)
+    }
+    return m
+  }, [groups, keptOverrides, defaultKeptSets])
+
+  const handleToggleKept = useCallback(
+    (group: DuplicateGroup, mediaKey: string) => {
+      setKeptOverrides((prev) => {
+        const current = prev[group.id] ?? defaultKeptSets.get(group.id) ?? new Set([group.originalMediaKey])
+        // Prevent removing the last kept item
+        if (current.has(mediaKey) && current.size === 1) return prev
+        const next = new Set(current)
+        if (next.has(mediaKey)) {
+          next.delete(mediaKey)
+        } else {
+          next.add(mediaKey)
+        }
+        return { ...prev, [group.id]: next }
+      })
+    },
+    [defaultKeptSets]
+  )
   const totalItems = state.status === "results" ? state.totalItems : 0
   const accountEmailForStorage = state.status === "results" ? state.accountEmail : undefined
   useEffect(() => {

--- a/tests/commands/google-photos-commands.test.ts
+++ b/tests/commands/google-photos-commands.test.ts
@@ -87,6 +87,92 @@ afterEach(() => {
 })
 
 // ============================================================
+// Unit tests: getAllMediaItems
+// ============================================================
+
+describe("getAllMediaItems — field mapping", () => {
+  function setupGptkApi(items: unknown[], nextPageId: string | null = null) {
+    ;(window as any).gptkApi = {
+      getItemsByUploadedDate: vi.fn().mockResolvedValue({ items, nextPageId }),
+    }
+  }
+
+  afterEach(() => {
+    delete (window as any).gptkApi
+  })
+
+  it("passes isOriginalQuality=true through to output item", async () => {
+    setupGptkApi([
+      {
+        mediaKey: "mk1",
+        dedupKey: "dk1",
+        thumb: "https://thumb/1",
+        timestamp: 1000,
+        creationTimestamp: 2000,
+        isOriginalQuality: true,
+      },
+    ])
+
+    const { messages, restore } = collectMessages()
+    sendCommand("getAllMediaItems", "req-oq-1", {})
+    await flush()
+
+    const result = messages.find(
+      (m: any) => m.action === "gptkResult" && m.command === "getAllMediaItems"
+    ) as any
+    expect(result?.success).toBe(true)
+    expect(result?.data[0].isOriginalQuality).toBe(true)
+    restore()
+  })
+
+  it("passes isOriginalQuality=false (storage saver) through to output item", async () => {
+    setupGptkApi([
+      {
+        mediaKey: "mk2",
+        dedupKey: "dk2",
+        thumb: "https://thumb/2",
+        timestamp: 1000,
+        creationTimestamp: 2000,
+        isOriginalQuality: false,
+      },
+    ])
+
+    const { messages, restore } = collectMessages()
+    sendCommand("getAllMediaItems", "req-oq-2", {})
+    await flush()
+
+    const result = messages.find(
+      (m: any) => m.action === "gptkResult" && m.command === "getAllMediaItems"
+    ) as any
+    expect(result?.data[0].isOriginalQuality).toBe(false)
+    restore()
+  })
+
+  it("maps undefined isOriginalQuality to null", async () => {
+    setupGptkApi([
+      {
+        mediaKey: "mk3",
+        dedupKey: "dk3",
+        thumb: "https://thumb/3",
+        timestamp: 1000,
+        creationTimestamp: 2000,
+        // isOriginalQuality intentionally absent
+      },
+    ])
+
+    const { messages, restore } = collectMessages()
+    sendCommand("getAllMediaItems", "req-oq-3", {})
+    await flush()
+
+    const result = messages.find(
+      (m: any) => m.action === "gptkResult" && m.command === "getAllMediaItems"
+    ) as any
+    expect(result?.data[0].isOriginalQuality).toBeNull()
+    restore()
+  })
+})
+
+// ============================================================
 // Unit tests: trashItems
 // ============================================================
 

--- a/tests/lib/duplicate-detector.test.ts
+++ b/tests/lib/duplicate-detector.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { communityDetection, matMul, topK, groupByTimestamp, withinGroupDuplicates } from "../../lib/duplicate-detector"
+import { communityDetection, matMul, topK, groupByTimestamp, withinGroupDuplicates, selectDefaultKeep } from "../../lib/duplicate-detector"
 import type { GpdMediaItem } from "../../lib/types"
 
 // ============================================================
@@ -413,5 +413,86 @@ describe("withinGroupDuplicates", () => {
     if (groups.length >= 2) {
       expect(groups[0].mediaKeys.length).toBeGreaterThanOrEqual(groups[1].mediaKeys.length)
     }
+  })
+})
+
+// ============================================================
+// selectDefaultKeep
+// ============================================================
+
+describe("selectDefaultKeep", () => {
+  function item(
+    key: string,
+    opts: {
+      isOriginalQuality?: boolean | null
+      resWidth?: number
+      resHeight?: number
+      creationTimestamp?: number
+    } = {},
+  ): GpdMediaItem {
+    return {
+      mediaKey: key,
+      dedupKey: key,
+      thumb: `https://example.com/${key}`,
+      timestamp: 0,
+      creationTimestamp: opts.creationTimestamp ?? 0,
+      resWidth: opts.resWidth,
+      resHeight: opts.resHeight,
+      isOriginalQuality: opts.isOriginalQuality,
+    }
+  }
+
+  it("prefers original quality over storage saver regardless of resolution", () => {
+    const saver = item("saver", { isOriginalQuality: false, resWidth: 4000, resHeight: 3000 })
+    const original = item("original", { isOriginalQuality: true, resWidth: 100, resHeight: 100 })
+    expect(selectDefaultKeep([saver, original])).toBe("original")
+  })
+
+  it("prefers original quality over null quality", () => {
+    const unknown = item("unknown", { isOriginalQuality: null, resWidth: 4000, resHeight: 3000 })
+    const original = item("original", { isOriginalQuality: true, resWidth: 100, resHeight: 100 })
+    expect(selectDefaultKeep([unknown, original])).toBe("original")
+  })
+
+  it("prefers null quality over storage saver", () => {
+    const saver = item("saver", { isOriginalQuality: false, resWidth: 4000, resHeight: 3000 })
+    const unknown = item("unknown", { isOriginalQuality: null, resWidth: 100, resHeight: 100 })
+    expect(selectDefaultKeep([saver, unknown])).toBe("unknown")
+  })
+
+  it("prefers higher resolution when quality is tied (both original)", () => {
+    const small = item("small", { isOriginalQuality: true, resWidth: 800, resHeight: 600 })
+    const large = item("large", { isOriginalQuality: true, resWidth: 3000, resHeight: 2000 })
+    expect(selectDefaultKeep([small, large])).toBe("large")
+  })
+
+  it("prefers higher resolution when quality is tied (both null)", () => {
+    const small = item("small", { resWidth: 800, resHeight: 600, creationTimestamp: 1 })
+    const large = item("large", { resWidth: 3000, resHeight: 2000, creationTimestamp: 2 })
+    expect(selectDefaultKeep([small, large])).toBe("large")
+  })
+
+  it("prefers oldest upload date as tiebreaker when quality and resolution are equal", () => {
+    const newer = item("newer", { isOriginalQuality: true, resWidth: 1920, resHeight: 1080, creationTimestamp: 200 })
+    const older = item("older", { isOriginalQuality: true, resWidth: 1920, resHeight: 1080, creationTimestamp: 100 })
+    expect(selectDefaultKeep([newer, older])).toBe("older")
+  })
+
+  it("handles undefined resolution fields (treats as 0 pixels)", () => {
+    const withRes = item("withRes", { resWidth: 1920, resHeight: 1080 })
+    const noRes = item("noRes", {})
+    expect(selectDefaultKeep([noRes, withRes])).toBe("withRes")
+  })
+
+  it("returns the single item in a one-item array", () => {
+    const only = item("only", { isOriginalQuality: true, resWidth: 1920, resHeight: 1080 })
+    expect(selectDefaultKeep([only])).toBe("only")
+  })
+
+  it("handles all items with equal criteria — returns first in stable order", () => {
+    const a = item("a", { isOriginalQuality: true, resWidth: 1920, resHeight: 1080, creationTimestamp: 0 })
+    const b = item("b", { isOriginalQuality: true, resWidth: 1920, resHeight: 1080, creationTimestamp: 0 })
+    const result = selectDefaultKeep([a, b])
+    expect(["a", "b"]).toContain(result)
   })
 })


### PR DESCRIPTION
## Summary

- Previously the oldest-uploaded photo was always pre-selected as Keep, causing Storage Saver copies uploaded years ago to be kept over higher-resolution originals
- New priority order: **original quality > higher resolution > oldest upload date**
- Smart selection runs at scan time (new scans) and at display time (`defaultKeptSets`), so already-stored results benefit without a re-scan

## Changes

- `lib/types.ts` — add `isOriginalQuality?: boolean | null` to `GpdMediaItem`
- `scripts/google-photos-commands.js` — pass `isOriginalQuality` through from GPTK
- `lib/duplicate-detector.ts` — new exported `selectDefaultKeep()` function; replaces the hardcoded oldest-upload default at all 3 group-build sites
- `tabs/app.tsx` — `defaultKeptSets` uses `selectDefaultKeep` so loaded-from-storage results get smart selection; `getKept` and `handleToggleKept` updated to use it consistently

## Test plan

- [x] 178 unit tests pass (`npm test`)
- [x] 18/18 integration tests pass
- [x] Manual: scan a library with Storage Saver items → confirm original-quality copy is pre-selected as Keep
- [x] Manual: verify user can still override Keep by clicking a different photo
- [x] Manual: load previously-stored scan results without re-scanning → confirm smart selection applies via `defaultKeptSets`