### PR TITLE
Pick a reachable Google Photos tab when multiple are open

### DIFF
--- a/background/index.ts
+++ b/background/index.ts
@@ -26,9 +26,48 @@ const pendingCommands: Record<
 // Find tabs
 // ============================================================
 
+/**
+ * Find a Google Photos tab that the bridge content script can actually reach.
+ *
+ * When the user has multiple photos.google.com tabs open (e.g. opened before
+ * the extension was installed, or duplicated via the "Open Google Photos"
+ * button), picking the first one returned by chrome.tabs.query is unreliable:
+ * the bridge may not be loaded in it, and chrome.tabs.sendMessage rejects with
+ * "Receiving end does not exist", surfacing as a spurious "Cannot connect to
+ * Google Photos" error.
+ *
+ * Strategy: prefer the active tab, then sort by lastAccessed descending, and
+ * ping each one until we find a reachable bridge. The bridge ignores
+ * unrecognized actions, so a no-op ping resolves with undefined when reachable
+ * and rejects when no content script is present.
+ */
 async function findGooglePhotosTab(): Promise<chrome.tabs.Tab | null> {
   const tabs = await chrome.tabs.query({ url: "https://photos.google.com/*" })
-  return tabs.length > 0 ? tabs[0] : null
+  if (tabs.length === 0) return null
+
+  // `lastAccessed` is available in Chrome 121+ but missing from this version
+  // of @types/chrome.
+  type TabWithLastAccessed = chrome.tabs.Tab & { lastAccessed?: number }
+  const sorted = [...tabs].sort((a, b) => {
+    if (a.active !== b.active) return a.active ? -1 : 1
+    const aAccessed = (a as TabWithLastAccessed).lastAccessed ?? 0
+    const bAccessed = (b as TabWithLastAccessed).lastAccessed ?? 0
+    return bAccessed - aAccessed
+  })
+
+  for (const candidate of sorted) {
+    if (!candidate.id) continue
+    try {
+      await chrome.tabs.sendMessage(candidate.id, {
+        app: APP_ID,
+        action: "ping",
+      })
+      return candidate
+    } catch {
+      // Bridge not loaded in this tab; try the next one.
+    }
+  }
+  return null
 }
 
 /**


### PR DESCRIPTION
## Summary

When the user has multiple `photos.google.com` tabs open, `findGooglePhotosTab` picks `tabs[0]` from `chrome.tabs.query`. That tab is often one where the bridge content script never loaded — typically:

- a tab that was open *before* the extension was installed (content scripts don't get injected into already-open tabs)
- a tab created by clicking the "Open Google Photos" button in the disconnected UI (each click spawns a new tab, but only one ends up with a fully-loaded bridge)

The result: `chrome.tabs.sendMessage` rejects with `Could not establish connection. Receiving end does not exist.`, surfacing in the UI as `Cannot connect to Google Photos. Please open photos.google.com in another tab.` — even though another `photos.google.com` tab works fine. Closing the bad tabs is not always practical (e.g. one is mid-upload).

## Fix

`findGooglePhotosTab` now:

1. Prefers the active tab, then sorts the rest by `lastAccessed` descending.
2. Pings each candidate via `chrome.tabs.sendMessage` (no-op `action: "ping"` — the bridge ignores unrecognized actions, so reachable tabs resolve with `undefined` and unreachable tabs reject).
3. Returns the first reachable one, or `null` if none respond.

`lastAccessed` exists on `Tab` since Chrome 121 but is missing from the bundled `@types/chrome`, so it's accessed through a small local intersection type.

## Repro

1. Open `photos.google.com`.
2. Install (or reload) the extension.
3. Open the extension app — it cannot connect.
4. Even after the user opens a fresh `photos.google.com` tab and signs in, the SW keeps picking the stale tab and the UI stays disconnected.

After the fix, the SW skips the stale tab and uses the working one.

## Test plan

- [x] `npm test` — all 178 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] Manual: with two `photos.google.com` tabs open (one stale, one freshly loaded), `Retry Connection` now succeeds instead of erroring
- [x] Manual: with one stale tab and zero reachable tabs, the UI still shows the disconnected state (no regression)