### PR TITLE
Detect duplicate videos and add tunable smart-mode time window

### DIFF
--- a/components/DuplicateGroups.tsx
+++ b/components/DuplicateGroups.tsx
@@ -17,6 +17,29 @@ import type { GpdMediaItem, DuplicateGroup } from "../lib/types"
 
 const PAGE_SIZE = 30
 
+/**
+ * Label a group as "videos", "photos", or "items" depending on the kinds of
+ * media inside. Groups with both kinds (rare, only possible if a video's
+ * poster happens to match a still) fall back to the neutral "items".
+ */
+function groupItemKind(
+  group: DuplicateGroup,
+  mediaItems: Record<string, GpdMediaItem>,
+): string {
+  let videos = 0
+  let total = 0
+  for (const key of group.mediaKeys) {
+    const item = mediaItems[key]
+    if (!item) continue
+    total++
+    if (item.duration) videos++
+  }
+  if (total === 0) return "items"
+  if (videos === total) return total === 1 ? "video" : "videos"
+  if (videos === 0) return total === 1 ? "photo" : "photos"
+  return "items"
+}
+
 // ── Hoisted static sx objects ──────────────────────────────────────────
 const sxPaperBase = { mb: 2, overflow: "hidden", borderRadius: 2, transition: "opacity 0.15s" }
 const sxGroupHeader = {
@@ -130,7 +153,7 @@ const DuplicateGroupRow = memo(function DuplicateGroupRow({
           sx={sxCheckbox}
         />
         <Typography variant="subtitle2" sx={{ flex: 1 }}>
-          {group.mediaKeys.length} photos
+          {group.mediaKeys.length} {groupItemKind(group, mediaItems)}
         </Typography>
         <Chip
           label={`${Math.round(group.similarity * 100)}% similar`}

--- a/components/ScanConfig.tsx
+++ b/components/ScanConfig.tsx
@@ -14,6 +14,14 @@ import SearchRoundedIcon from "@mui/icons-material/SearchRounded"
 import WarningAmberRoundedIcon from "@mui/icons-material/WarningAmberRounded"
 import type { ScanSettings } from "../lib/types"
 
+function formatWindow(sec: number): string {
+  if (sec < 60) return `${sec}s`
+  if (sec < 3600) return `${Math.round(sec / 60)}m`
+  if (sec < 86400) return `${Math.round(sec / 3600)}h`
+  if (sec < 604800) return `${Math.round(sec / 86400)}d`
+  return `${Math.round(sec / 604800)}w`
+}
+
 interface ScanConfigProps {
   settings: ScanSettings
   onSettingsChange: (settings: Partial<ScanSettings>) => void
@@ -102,6 +110,31 @@ export function ScanConfig({
                   : "Compares all photos against each other — thorough but slow for large libraries."}
               </Typography>
             </Box>
+
+            {settings.scanMode === "smart" && (
+              <Box sx={{ mb: 3 }}>
+                <Typography variant="body2" fontWeight={500} sx={{ mb: 1 }}>
+                  Time window: <strong>{formatWindow(settings.smartWindowSec ?? 1)}</strong>
+                </Typography>
+                <ToggleButtonGroup
+                  value={settings.smartWindowSec ?? 1}
+                  exclusive
+                  size="small"
+                  fullWidth
+                  onChange={(_, value) => {
+                    if (value !== null) onSettingsChange({ smartWindowSec: value })
+                  }}>
+                  <ToggleButton value={1}>1s</ToggleButton>
+                  <ToggleButton value={60}>1m</ToggleButton>
+                  <ToggleButton value={3600}>1h</ToggleButton>
+                  <ToggleButton value={86400}>1d</ToggleButton>
+                  <ToggleButton value={604800}>1w</ToggleButton>
+                </ToggleButtonGroup>
+                <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5 }}>
+                  How close in time items must be to be compared. Widen this to catch re-saved videos whose EXIF date was rewritten — at the cost of more pairs to check.
+                </Typography>
+              </Box>
+            )}
 
             <Box>
               <Typography variant="body2" fontWeight={500} sx={{ mb: 1 }}>

--- a/lib/duplicate-detector.ts
+++ b/lib/duplicate-detector.ts
@@ -161,7 +161,10 @@ export async function fullDetectDuplicates(
   const scanStart = performance.now();
 
   // Filter to items with thumbnails (photos only, skip videos)
-  const candidates = mediaItems.filter((item) => item.thumb && !item.duration);
+  // Include items with thumbnails. Video posters work too — two copies of the
+  // same clip have identical poster frames, which produce near-identical
+  // embeddings.
+  const candidates = mediaItems.filter((item) => item.thumb);
   console.log(
     `[GPD] detectDuplicates: ${mediaItems.length} items → ${candidates.length} candidates`,
   );
@@ -463,7 +466,10 @@ export async function smartDetectDuplicates(
   logger?: ScanLogger,
 ): Promise<DuplicateGroup[]> {
   const scanStart = performance.now();
-  const candidates = mediaItems.filter((item) => item.thumb && !item.duration);
+  // Include items with thumbnails. Video posters work too — two copies of the
+  // same clip have identical poster frames, which produce near-identical
+  // embeddings.
+  const candidates = mediaItems.filter((item) => item.thumb);
 
   // Step 1: Bucket by timestamp — no I/O, instant
   const buckets = groupByTimestamp(candidates, windowMs);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -198,6 +198,14 @@ export interface StoredState {
 export interface ScanSettings {
   similarityThreshold: number;
   scanMode: ScanMode;
+  /**
+   * Smart-mode timestamp bucket window in seconds. Items with `taken` dates
+   * within this window are compared against each other. Default is 1 second
+   * (matches the legacy hardcoded value). Widen to catch re-saved videos /
+   * photos whose EXIF timestamp was rewritten — at the cost of more pairs to
+   * compare.
+   */
+  smartWindowSec?: number;
   dateRange?: {
     from?: string;
     to?: string;
@@ -207,4 +215,5 @@ export interface ScanSettings {
 export const DEFAULT_SETTINGS: ScanSettings = {
   similarityThreshold: 0.99,
   scanMode: "smart",
+  smartWindowSec: 1,
 };

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -311,7 +311,7 @@ export default function App() {
             ? await smartDetectDuplicates(
                 items,
                 settingsRef.current.similarityThreshold,
-                1000,
+                (settingsRef.current.smartWindowSec ?? 1) * 1000,
                 onProgressCallback,
                 signal,
                 logger


### PR DESCRIPTION
## Summary

Two related improvements that unlock duplicate detection for video and let the user tune the smart-mode time window without recompiling.

### 1. Videos

Both \`fullDetectDuplicates\` and \`smartDetectDuplicates\` filtered out everything with a \`duration\` field, so video posters never reached the MediaPipe pipeline. But Google Photos serves a poster (effectively the first/key frame) as the same \`thumb\` URL that photos use — and for two copies of the same clip those posters are pixel-identical, which produces near-identical MobileNetV3 embeddings. Removing the filter is enough to catch real video duplicates with the same threshold mechanic.

To make the result legible the group header now labels each row as \`N videos\`, \`N photos\`, or \`N items\` (mixed) instead of always \`N photos\`.

### 2. Tunable smart window

\`smartDetectDuplicates\` was called with a hardcoded \`1000ms\` timestamp bucket. That window works for burst captures but misses duplicates whose EXIF \`taken\` date diverged between copies — typically:

- a video re-saved by an editor (timestamp gets rewritten to the export date)
- a photo re-encoded in a different timezone (drift by hours)
- a re-upload where Google itself recomputed the timestamp

\`ScanSettings\` now carries \`smartWindowSec\` (default \`1\`, preserves existing behavior), exposed in the Smart-mode "More options" as a 1s/1m/1h/1d/1w ToggleButtonGroup. The user picks a wider window when they need to catch re-saved media; the cost is more pairs to compare, but pairwise cosine on cached embeddings is cheap.

## Repro for the video case

1. Upload the same MP4 twice to Google Photos (e.g. once from the phone and once from a desktop drag-drop) — the dedupKey will differ.
2. Run a scan on \`main\` → 0 groups containing the clip.
3. Apply this PR, re-scan → both copies appear in a group labeled \`2 videos\` with high similarity.

## Repro for the wider window

1. Find an item whose taken date got rewritten on re-save (smart mode misses it on \`main\` because the duplicate sits in a different timestamp bucket).
2. Apply this PR, set the window to \`1d\` (or wider), re-scan → the pair appears.

## Test plan

- [x] \`npm test\` — all 178 tests pass
- [x] \`npx tsc --noEmit\` — no type errors
- [x] Smart mode default (1s window): scan finishes with same behavior as \`main\` for photo-only libraries
- [x] Smart mode 1d window: catches re-saved videos that the 1s window misses
- [x] Full mode: also picks up video duplicates without any new option
- [x] Mixed video+photo group labels render \`items\`; all-photo groups render \`photos\`; all-video groups render \`videos\`