### PR TITLE
Fix scan hangs: retry healthCheck on connect, time out gptk pages

### DIFF
--- a/scripts/google-photos-commands.js
+++ b/scripts/google-photos-commands.js
@@ -73,13 +73,38 @@ async function getAllMediaItems(requestId, args) {
   const sinceTimestamp =
     args && args.sinceTimestamp ? args.sinceTimestamp : null
 
+  // Per-page timeout. Google's pagination endpoint occasionally hangs without
+  // ever rejecting fetch(), which used to lock the UI on "Fetching media
+  // items" indefinitely. A timeout lets us surface a real error to the user.
+  const PAGE_TIMEOUT_MS = 60_000
+
+  function withTimeout(promise, ms, label) {
+    let timer
+    const timeout = new Promise((_, reject) => {
+      timer = setTimeout(
+        () =>
+          reject(
+            new Error(
+              `${label} timed out after ${Math.round(ms / 1000)}s. Google's API likely stalled — please re-scan.`
+            )
+          ),
+        ms
+      )
+    })
+    return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
+  }
+
   try {
     let nextPageId = null
     const mediaItems = []
     let reachedCache = false
 
     do {
-      const page = await gptkApi.getItemsByUploadedDate(nextPageId)
+      const page = await withTimeout(
+        gptkApi.getItemsByUploadedDate(nextPageId),
+        PAGE_TIMEOUT_MS,
+        "Fetching page from Google Photos"
+      )
       if (!page) {
         console.warn("GPD: Empty page response, stopping pagination")
         break

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -51,6 +51,12 @@ import type {
 // Helpers
 // ============================================================
 
+// Initial healthCheck retries. The first probe often fails on a freshly
+// opened app tab because the bridge content script on photos.google.com has
+// not finished loading yet, or because the MV3 service worker is still
+// spinning up from idle. Backoff: 400ms, 800ms, 1600ms, 3200ms (5 attempts).
+const HEALTH_CHECK_MAX_ATTEMPTS = 5
+
 function generateRequestId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 }
@@ -119,6 +125,10 @@ export default function App() {
   // scans killed by reload can be dropped (they arrive late from the GP tab)
   const currentScanRequestIdRef = useRef<string | null>(null)
 
+  // Counts failed healthCheck attempts during initial connect so we can retry
+  // silently before showing a disconnected error.
+  const healthCheckAttemptsRef = useRef(0)
+
   // Holds selections loaded from storage; applied once when groups first load
   const pendingSelectionsRef = useRef<{
     selectedGroupIds: Set<string>
@@ -180,12 +190,33 @@ export default function App() {
       if (sender.tab) return
 
       switch (message.action) {
-        case "healthCheck.result":
+        case "healthCheck.result": {
+          const msg = message as HealthCheckResultMessage
+          // Swallow early "failed" results and retry — when the app tab opens
+          // before the bridge content script has fully loaded on a fresh
+          // photos.google.com tab, or when the service worker has just woken
+          // up from MV3 idle, the first probe often misses. Without this the
+          // user sees a spurious "disconnected" flash and has to manually hit
+          // Retry. We give up after a few attempts and let the reducer show
+          // the error.
+          if (
+            !msg.success &&
+            healthCheckAttemptsRef.current < HEALTH_CHECK_MAX_ATTEMPTS - 1
+          ) {
+            healthCheckAttemptsRef.current++
+            const delay = 400 * Math.pow(2, healthCheckAttemptsRef.current - 1)
+            window.setTimeout(() => {
+              sendToServiceWorker({ app: APP_ID, action: "healthCheck" })
+            }, delay)
+            return
+          }
+          if (msg.success) healthCheckAttemptsRef.current = 0
           dispatch({
             type: "HEALTH_CHECK_RESULT",
-            payload: message as HealthCheckResultMessage
+            payload: msg
           })
           break
+        }
         case "gptkResult": {
           const result = message as GptkResultMessage
           if (result.command === "getAllMediaItems") {
@@ -620,6 +651,7 @@ export default function App() {
 
   const handleReset = useCallback(() => {
     dispatch({ type: "RESET" })
+    healthCheckAttemptsRef.current = 0
     sendToServiceWorker({ app: APP_ID, action: "healthCheck" })
   }, [])
 


### PR DESCRIPTION
## Summary

Two reliability fixes that surface as the same UX bug — the app appearing to hang with no way forward — but have different root causes.

### 1. healthCheck retries on app tab open

**Symptom:** Open the extension app, immediately see the disconnected screen \`Cannot connect to Google Photos\`. Hit \`Retry Connection\` and it works.

**Cause:** When the app tab is created from the popup, its first \`chrome.runtime.sendMessage({ action: \"healthCheck\" })\` races against:

- the bridge content script finishing load on a fresh \`photos.google.com\` tab (a few hundred ms after \`document_idle\`)
- the MV3 service worker spinning up from idle (also a few hundred ms cold)

If either loses the race, the SW responds \`success: false\`, the reducer flips to \`disconnected\`, and the user has to manually retry — even though half a second of waiting would have worked.

**Fix:** Swallow up to 4 early \`success:false\` probes and retry with 400/800/1600/3200ms backoff (\`HEALTH_CHECK_MAX_ATTEMPTS = 5\` total over ~6s). Fall through to the existing reducer behavior on the final attempt, so the disconnected screen only appears when the connection actually doesn't recover. The counter resets on manual \`Retry Connection\` so the user can still trigger a fresh round.

### 2. Per-page timeout in getAllMediaItems

**Symptom:** Scan stuck on \`Fetching media items\` with the same item count for hours. Only \`Cancel\` works, and even after Cancel the underlying fetch in the MAIN-world keeps the socket open until the user reloads photos.google.com.

**Cause:** \`gptkApi.getItemsByUploadedDate(nextPageId)\` occasionally never resolves or rejects — fetch() opens the socket and then hangs. There's no \`AbortSignal\`/timeout on that call, so the \`do/while\` loop in \`getAllMediaItems\` waits forever.

**Fix:** Wrap each page fetch in a \`Promise.race\` against a 60s timeout. On timeout the existing \`catch\` in \`getAllMediaItems\` surfaces a clear error to the user via \`postError\` → \`SCAN_ERROR\` reducer → \"disconnected\" screen with actionable text (\"Google's API likely stalled — please re-scan\") instead of an indefinite spinner.

## Repro

**Connect race (1):** Hard-reload photos.google.com, then immediately open the extension via the toolbar icon while the page is still loading. On \`main\` you'll see \`Cannot connect\` for half a second to a few seconds, then \`Retry Connection\` works. With this PR the disconnected screen never appears.

**Hung fetch (2):** Harder to reliably repro since it depends on Google's API behavior, but observed in practice on a 20k+ item library: scan progresses to ~8,300 items then \`itemsProcessed\` stops changing while the UI shows the indeterminate \"Fetching media items\" spinner. With this PR, after 60s the spinner is replaced by the disconnected error with the timeout message.

## Test plan

- [x] \`npm test\` — all 178 tests pass
- [x] \`npx tsc --noEmit\` — no type errors
- [x] Connect race: opening app tab while photos.google.com is mid-load now shows a connecting spinner that resolves to \`connected\` instead of flashing \`disconnected\`.
- [x] Manual Retry still works (counter resets on \`handleReset\`).
- [x] Genuinely-unreachable case (e.g. no \`photos.google.com\` tab open at all) still shows the disconnected screen after the retries.