### PR TITLE
Shortcuts in Fullscreen: item keep/trash and group navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ docs/
 .vscode/tasks.json
 .DS_Store
 *:Zone.Identifier
+
+# Local Chrome Debug Profiles
+.chrome-profile/
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,16 @@ Do **not** use `npm run build` for development — that builds prod and overwrit
 
 ---
 
+**Note**: In newer versions of Chrome (v137 and later), the `--load-extension` CLI flag is completely ignored on standard builds for security reasons. Unpacked extensions must be loaded **manually once** via the `chrome://extensions` page with **Developer mode** enabled.
+
 Chrome must be running with remote debugging enabled on port 9222. If not started:
+
+**macOS:**
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222 --user-data-dir=".chrome-profile" --no-first-run
+```
+
+**Windows [WSL]:**
 ```bash
 "/mnt/c/Program Files/Google/Chrome/Application/chrome.exe" --remote-debugging-port=9222 --user-data-dir="C:\Users\mackt\Chrome Profiles\chrome-debug" --no-first-run
 ```

--- a/components/DuplicateGroups.tsx
+++ b/components/DuplicateGroups.tsx
@@ -301,6 +301,22 @@ export function DuplicateGroups({
     setViewerState({ group, index })
   }, [])
 
+  const currentGroupIndex = viewerState
+    ? groups.findIndex((g) => g.id === viewerState.group.id)
+    : -1
+
+  const handleNextGroup = useCallback(() => {
+    if (currentGroupIndex !== -1 && currentGroupIndex < groups.length - 1) {
+      setViewerState({ group: groups[currentGroupIndex + 1], index: 0 })
+    }
+  }, [currentGroupIndex, groups])
+
+  const handlePrevGroup = useCallback(() => {
+    if (currentGroupIndex > 0) {
+      setViewerState({ group: groups[currentGroupIndex - 1], index: 0 })
+    }
+  }, [currentGroupIndex, groups])
+
   const viewerItems = useMemo(() => {
     if (!viewerState) return []
     return viewerState.group.mediaKeys
@@ -354,6 +370,10 @@ export function DuplicateGroups({
           keptSet={keptByGroupId.get(viewerState.group.id)!}
           isGroupSelected={selectedGroupIds.has(viewerState.group.id)}
           onClose={() => setViewerState(null)}
+          onToggleKept={(mediaKey) => onToggleKept(viewerState.group, mediaKey)}
+          onToggleGroup={() => onToggleGroup(viewerState.group.id)}
+          onNextGroup={handleNextGroup}
+          onPrevGroup={handlePrevGroup}
         />
       )}
     </Box>

--- a/components/DuplicateGroups.tsx
+++ b/components/DuplicateGroups.tsx
@@ -301,9 +301,11 @@ export function DuplicateGroups({
     setViewerState({ group, index })
   }, [])
 
-  const currentGroupIndex = viewerState
-    ? groups.findIndex((g) => g.id === viewerState.group.id)
-    : -1
+  const currentGroupIndex = useMemo(() => {
+    return viewerState
+      ? groups.findIndex((g) => g.id === viewerState.group.id)
+      : -1
+  }, [viewerState, groups])
 
   const handleNextGroup = useCallback(() => {
     if (currentGroupIndex !== -1 && currentGroupIndex < groups.length - 1) {

--- a/components/PhotoViewerModal.tsx
+++ b/components/PhotoViewerModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useCallback, useState, useEffect } from "react"
 import { keyframes } from "@emotion/react"
 import Box from "@mui/material/Box"
 import CardMedia from "@mui/material/CardMedia"
@@ -145,11 +145,13 @@ export function PhotoViewerModal({
     setIndex(initialIndex)
   }, [open, initialIndex, items])
 
-  const navigate = (newIndex: number) => {
-    if (newIndex === index) return
-    setSlideDir(newIndex > index ? "forward" : "backward")
-    setIndex(newIndex)
-  }
+  const navigate = useCallback((newIndex: number) => {
+    setIndex((prev) => {
+      if (newIndex === prev) return prev
+      setSlideDir(newIndex > prev ? "forward" : "backward")
+      return newIndex
+    })
+  }, [])
 
   // Keyboard navigation (arrow keys only; MUI Dialog handles Escape → onClose)
   useEffect(() => {
@@ -180,11 +182,13 @@ export function PhotoViewerModal({
         } else if (e.key === "ArrowRight") {
           navigate(Math.min(items.length - 1, index + 1))
         } else if (e.key === "ArrowUp") {
+          e.preventDefault()
           const item = items[Math.min(index, items.length - 1)]
           if (item && !keptSet.has(item.mediaKey)) {
             onToggleKept?.(item.mediaKey)
           }
         } else if (e.key === "ArrowDown") {
+          e.preventDefault()
           const item = items[Math.min(index, items.length - 1)]
           if (item && keptSet.has(item.mediaKey)) {
             onToggleKept?.(item.mediaKey)
@@ -426,6 +430,7 @@ export function PhotoViewerModal({
         onClose={() => setShortcutsOpen(false)}
         maxWidth="xs"
         fullWidth
+        aria-label="Keyboard shortcuts"
         PaperProps={{
           sx: {
             bgcolor: "#222",

--- a/components/PhotoViewerModal.tsx
+++ b/components/PhotoViewerModal.tsx
@@ -12,6 +12,7 @@ import Typography from "@mui/material/Typography"
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft"
 import ChevronRightIcon from "@mui/icons-material/ChevronRight"
 import CloseIcon from "@mui/icons-material/Close"
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline"
 import OpenInNewIcon from "@mui/icons-material/OpenInNew"
 import type { GpdMediaItem } from "../lib/types"
 
@@ -105,6 +106,10 @@ export interface PhotoViewerModalProps {
   keptSet: Set<string>
   isGroupSelected: boolean
   onClose: () => void
+  onToggleKept?: (mediaKey: string) => void
+  onToggleGroup?: () => void
+  onNextGroup?: () => void
+  onPrevGroup?: () => void
 }
 
 const slideInFromRight = keyframes`
@@ -123,17 +128,22 @@ export function PhotoViewerModal({
   keptSet,
   isGroupSelected,
   onClose,
+  onToggleKept,
+  onToggleGroup,
+  onNextGroup,
+  onPrevGroup,
 }: PhotoViewerModalProps) {
   const [index, setIndex] = useState(initialIndex)
   const [slideDir, setSlideDir] = useState<"forward" | "backward">("forward")
+  const [shortcutsOpen, setShortcutsOpen] = useState(false)
 
   // Preload all images in the group up front
   const blobUrls = useGroupBlobUrls(items)
 
-  // Reset index when the modal opens or the initial photo changes
+  // Reset index when the modal opens, the initial photo changes, or the items change
   useEffect(() => {
     setIndex(initialIndex)
-  }, [open, initialIndex])
+  }, [open, initialIndex, items])
 
   const navigate = (newIndex: number) => {
     if (newIndex === index) return
@@ -145,12 +155,46 @@ export function PhotoViewerModal({
   useEffect(() => {
     if (!open) return
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "ArrowLeft") navigate(Math.max(0, index - 1))
-      if (e.key === "ArrowRight") navigate(Math.min(items.length - 1, index + 1))
+      if (e.shiftKey) {
+        if (e.key === "ArrowUp") {
+          e.preventDefault()
+          if (!isGroupSelected) {
+            onToggleGroup?.()
+          }
+          onNextGroup?.()
+        } else if (e.key === "ArrowDown") {
+          e.preventDefault()
+          if (isGroupSelected) {
+            onToggleGroup?.()
+          }
+        } else if (e.key === "ArrowLeft") {
+          e.preventDefault()
+          onPrevGroup?.()
+        } else if (e.key === "ArrowRight") {
+          e.preventDefault()
+          onNextGroup?.()
+        }
+      } else {
+        if (e.key === "ArrowLeft") {
+          navigate(Math.max(0, index - 1))
+        } else if (e.key === "ArrowRight") {
+          navigate(Math.min(items.length - 1, index + 1))
+        } else if (e.key === "ArrowUp") {
+          const item = items[Math.min(index, items.length - 1)]
+          if (item && !keptSet.has(item.mediaKey)) {
+            onToggleKept?.(item.mediaKey)
+          }
+        } else if (e.key === "ArrowDown") {
+          const item = items[Math.min(index, items.length - 1)]
+          if (item && keptSet.has(item.mediaKey)) {
+            onToggleKept?.(item.mediaKey)
+          }
+        }
+      }
     }
     window.addEventListener("keydown", handler)
     return () => window.removeEventListener("keydown", handler)
-  }, [open, index, items.length])
+  }, [open, index, items, keptSet, isGroupSelected, onToggleKept, onToggleGroup, onNextGroup, onPrevGroup])
 
   if (items.length === 0) return null
 
@@ -365,7 +409,64 @@ export function PhotoViewerModal({
             <OpenInNewIcon sx={{ fontSize: 12 }} />
           </Link>
         )}
+
+        {/* Shortcuts Help Button */}
+        <IconButton
+          onClick={() => setShortcutsOpen(true)}
+          size="small"
+          aria-label="Keyboard shortcuts"
+          sx={{ color: "rgba(255,255,255,0.7)", "&:hover": { color: "white" } }}>
+          <HelpOutlineIcon sx={{ fontSize: 18 }} />
+        </IconButton>
       </Box>
+
+      {/* Shortcuts Modal */}
+      <Dialog
+        open={shortcutsOpen}
+        onClose={() => setShortcutsOpen(false)}
+        maxWidth="xs"
+        fullWidth
+        PaperProps={{
+          sx: {
+            bgcolor: "#222",
+            color: "white",
+          },
+        }}>
+        <Box sx={{ p: 2, display: "flex", justifyContent: "space-between", alignItems: "center", borderBottom: "1px solid rgba(255,255,255,0.1)" }}>
+          <Typography variant="h6" sx={{ fontSize: "1.1rem" }}>Keyboard Shortcuts</Typography>
+          <IconButton onClick={() => setShortcutsOpen(false)} size="small" sx={{ color: "white" }}>
+            <CloseIcon />
+          </IconButton>
+        </Box>
+        <DialogContent sx={{ p: 0 }}>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, p: 2 }}>
+            <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+              <Typography variant="body2" sx={{ color: "rgba(255,255,255,0.7)" }}>Previous / Next photo</Typography>
+              <Typography variant="body2" sx={{ fontFamily: "monospace" }}>← / →</Typography>
+            </Box>
+            <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+              <Typography variant="body2" sx={{ color: "rgba(255,255,255,0.7)" }}>Keep photo</Typography>
+              <Typography variant="body2" sx={{ fontFamily: "monospace" }}>↑</Typography>
+            </Box>
+            <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+              <Typography variant="body2" sx={{ color: "rgba(255,255,255,0.7)" }}>Trash photo</Typography>
+              <Typography variant="body2" sx={{ fontFamily: "monospace" }}>↓</Typography>
+            </Box>
+            <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+              <Typography variant="body2" sx={{ color: "rgba(255,255,255,0.7)" }}>Previous / Next group</Typography>
+              <Typography variant="body2" sx={{ fontFamily: "monospace" }}>Shift + ← / →</Typography>
+            </Box>
+            <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+              <Typography variant="body2" sx={{ color: "rgba(255,255,255,0.7)" }}>Confirm group's choices & Next</Typography>
+              <Typography variant="body2" sx={{ fontFamily: "monospace" }}>Shift + ↑</Typography>
+            </Box>
+            <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+              <Typography variant="body2" sx={{ color: "rgba(255,255,255,0.7)" }}>Unconfirm group</Typography>
+              <Typography variant="body2" sx={{ fontFamily: "monospace" }}>Shift + ↓</Typography>
+            </Box>
+          </Box>
+        </DialogContent>
+      </Dialog>
     </Dialog>
   )
 }

--- a/tests/components/photo-viewer-modal.test.tsx
+++ b/tests/components/photo-viewer-modal.test.tsx
@@ -197,10 +197,27 @@ describe("PhotoViewerModal — navigation", () => {
     expect(screen.getByText(/1 \/ 3/)).toBeInTheDocument()
   })
 
-  it("does not go above last index with ArrowRight at last item", () => {
-    wrap(<PhotoViewerModal {...defaultProps} initialIndex={2} />)
-    fireEvent.keyDown(window, { key: "ArrowRight" })
-    expect(screen.getByText(/3 \/ 3/)).toBeInTheDocument()
+  it("resets index to initialIndex when items change", () => {
+    const { rerender } = wrap(<PhotoViewerModal {...defaultProps} initialIndex={0} />)
+    
+    // Navigate to next photo (index 1)
+    fireEvent.click(screen.getByRole("button", { name: /next photo/i }))
+    expect(screen.getByText(/2 \/ 3/)).toBeInTheDocument()
+    
+    // Now rerender with a new set of items
+    const newItems = [makeItem("new1"), makeItem("new2")]
+    rerender(
+      <ThemeProvider theme={theme}>
+        <PhotoViewerModal
+          {...defaultProps}
+          items={newItems}
+          initialIndex={0}
+        />
+      </ThemeProvider>
+    )
+    
+    // Verify it reset to photo 1 of the new items
+    expect(screen.getByText(/1 \/ 2/)).toBeInTheDocument()
   })
 })
 
@@ -234,5 +251,151 @@ describe("PhotoViewerModal — close", () => {
     wrap(<PhotoViewerModal {...defaultProps} onClose={onClose} />)
     fireEvent.click(screen.getByRole("button", { name: /close photo viewer/i }))
     expect(onClose).toHaveBeenCalledOnce()
+  })
+})
+
+// ============================================================
+// Keyboard Keep Toggling (ArrowUp / ArrowDown)
+// ============================================================
+
+describe("PhotoViewerModal — keyboard keep toggling", () => {
+  it("calls onToggleKept when pressing ArrowUp on a non-kept image", () => {
+    const onToggleKept = vi.fn()
+    wrap(
+      <PhotoViewerModal
+        {...defaultProps}
+        initialIndex={1}
+        onToggleKept={onToggleKept}
+      />
+    )
+    fireEvent.keyDown(window, { key: "ArrowUp" })
+    expect(onToggleKept).toHaveBeenCalledWith("img2")
+  })
+
+  it("does NOT call onToggleKept when pressing ArrowUp on an already kept image", () => {
+    const onToggleKept = vi.fn()
+    wrap(
+      <PhotoViewerModal
+        {...defaultProps}
+        initialIndex={0}
+        onToggleKept={onToggleKept}
+      />
+    )
+    fireEvent.keyDown(window, { key: "ArrowUp" })
+    expect(onToggleKept).not.toHaveBeenCalled()
+  })
+
+  it("calls onToggleKept when pressing ArrowDown on a kept image", () => {
+    const onToggleKept = vi.fn()
+    wrap(
+      <PhotoViewerModal
+        {...defaultProps}
+        initialIndex={0}
+        onToggleKept={onToggleKept}
+      />
+    )
+    fireEvent.keyDown(window, { key: "ArrowDown" })
+    expect(onToggleKept).toHaveBeenCalledWith("img1")
+  })
+
+  it("does NOT call onToggleKept when pressing ArrowDown on a non-kept image", () => {
+    const onToggleKept = vi.fn()
+    wrap(
+      <PhotoViewerModal
+        {...defaultProps}
+        initialIndex={1}
+        onToggleKept={onToggleKept}
+      />
+    )
+    fireEvent.keyDown(window, { key: "ArrowDown" })
+    expect(onToggleKept).not.toHaveBeenCalled()
+  })
+})
+
+// ============================================================
+// Shift Keyboard Group Shortcuts
+// ============================================================
+
+describe("PhotoViewerModal — Shift keyboard group shortcuts", () => {
+  it("calls onToggleGroup (if not selected) and onNextGroup on Shift + ArrowUp", () => {
+    const onToggleGroup = vi.fn()
+    const onNextGroup = vi.fn()
+    wrap(
+      <PhotoViewerModal
+        {...defaultProps}
+        isGroupSelected={false}
+        onToggleGroup={onToggleGroup}
+        onNextGroup={onNextGroup}
+      />
+    )
+    fireEvent.keyDown(window, { key: "ArrowUp", shiftKey: true })
+    expect(onToggleGroup).toHaveBeenCalledOnce()
+    expect(onNextGroup).toHaveBeenCalledOnce()
+  })
+
+  it("does NOT call onToggleGroup (if already selected) but still calls onNextGroup on Shift + ArrowUp", () => {
+    const onToggleGroup = vi.fn()
+    const onNextGroup = vi.fn()
+    wrap(
+      <PhotoViewerModal
+        {...defaultProps}
+        isGroupSelected={true}
+        onToggleGroup={onToggleGroup}
+        onNextGroup={onNextGroup}
+      />
+    )
+    fireEvent.keyDown(window, { key: "ArrowUp", shiftKey: true })
+    expect(onToggleGroup).not.toHaveBeenCalled()
+    expect(onNextGroup).toHaveBeenCalledOnce()
+  })
+
+  it("calls onToggleGroup on Shift + ArrowDown if group is selected", () => {
+    const onToggleGroup = vi.fn()
+    wrap(
+      <PhotoViewerModal
+        {...defaultProps}
+        isGroupSelected={true}
+        onToggleGroup={onToggleGroup}
+      />
+    )
+    fireEvent.keyDown(window, { key: "ArrowDown", shiftKey: true })
+    expect(onToggleGroup).toHaveBeenCalledOnce()
+  })
+
+  it("does NOT call onToggleGroup on Shift + ArrowDown if group is not selected", () => {
+    const onToggleGroup = vi.fn()
+    wrap(
+      <PhotoViewerModal
+        {...defaultProps}
+        isGroupSelected={false}
+        onToggleGroup={onToggleGroup}
+      />
+    )
+    fireEvent.keyDown(window, { key: "ArrowDown", shiftKey: true })
+    expect(onToggleGroup).not.toHaveBeenCalled()
+  })
+
+  it("calls onPrevGroup on Shift + ArrowLeft", () => {
+    const onPrevGroup = vi.fn()
+    wrap(
+      <PhotoViewerModal
+        {...defaultProps}
+        onPrevGroup={onPrevGroup}
+      />
+    )
+    fireEvent.keyDown(window, { key: "ArrowLeft", shiftKey: true })
+    expect(onPrevGroup).toHaveBeenCalledOnce()
+  })
+
+  it("calls onNextGroup on Shift + ArrowRight", () => {
+    const onNextGroup = vi.fn()
+    wrap(
+      <PhotoViewerModal
+        {...defaultProps}
+        onNextGroup={onNextGroup}
+      />
+    )
+    fireEvent.keyDown(window, { key: "ArrowRight", shiftKey: true })
+    expect(onNextGroup).toHaveBeenCalledOnce()
   })
 })

--- a/tests/components/photo-viewer-modal.test.tsx
+++ b/tests/components/photo-viewer-modal.test.tsx
@@ -197,6 +197,12 @@ describe("PhotoViewerModal — navigation", () => {
     expect(screen.getByText(/1 \/ 3/)).toBeInTheDocument()
   })
 
+  it("does not go above last index with ArrowRight at last item", () => {
+    wrap(<PhotoViewerModal {...defaultProps} initialIndex={2} />)
+    fireEvent.keyDown(window, { key: "ArrowRight" })
+    expect(screen.getByText(/3 \/ 3/)).toBeInTheDocument()
+  })
+
   it("resets index to initialIndex when items change", () => {
     const { rerender } = wrap(<PhotoViewerModal {...defaultProps} initialIndex={0} />)
     


### PR DESCRIPTION
**Shortcuts Functionality:**

Item actions:
Arrow Up : keep photo
Arrow Down : trash photo

Group selection
Shift + Up : "confirm group's choices" – select group, then open next group (open 1st photo)
Shift + Down : deselect group

Group navigation
Shift + Left : skip to next group (open 1st photo)
Shift + Left : skip to previous group (open 1st photo)

**Documentation:**
CLAUDE.md: Instruction for Mac. Instruction for new Chrome versions.

<img width="1416" height="834" alt="image" src="https://github.com/user-attachments/assets/69ca6891-f038-4811-9704-37a66f7fd9ba" />
