### PR TITLE
Add test coverage for recent PRs (#120–#123)

### DIFF
--- a/tests/background/service-worker.test.ts
+++ b/tests/background/service-worker.test.ts
@@ -149,6 +149,153 @@ describe("healthCheck", () => {
 })
 
 // ============================================================
+// findGooglePhotosTab — multi-tab selection (PR #120)
+//
+// When several photos.google.com tabs are open, picking tabs[0] was
+// unreliable: the bridge may not be loaded in it, and sendMessage rejects
+// with "Receiving end does not exist". The SW now pings each candidate —
+// preferring the active tab, then most-recently-accessed — until one replies.
+// ============================================================
+
+describe("findGooglePhotosTab — multi-tab selection", () => {
+  /** Filter recorded sendMessage calls down to ping probes. */
+  function pingCalls() {
+    return mockChrome.tabs.sendMessage.mock.calls.filter(
+      (c: unknown[]) => (c[1] as { action?: string })?.action === "ping"
+    )
+  }
+
+  it("skips an unreachable tab and forwards to the reachable one", async () => {
+    const unreachableId = 31
+    const reachableId = 32
+    const appTabId = 33
+
+    mockChrome.tabs.query.mockImplementation((query: { url?: string }) => {
+      if (query?.url?.includes("photos.google.com"))
+        return Promise.resolve([
+          { id: unreachableId, active: false, lastAccessed: 200 },
+          { id: reachableId, active: false, lastAccessed: 100 },
+        ])
+      return Promise.resolve([{ id: appTabId }])
+    })
+
+    mockChrome.tabs.sendMessage.mockImplementation(
+      (
+        tabId: number,
+        msg: { action?: string; command?: string; requestId?: string }
+      ) => {
+        // The more-recently-accessed tab has no bridge loaded → ping rejects.
+        if (msg?.action === "ping") {
+          return tabId === unreachableId
+            ? Promise.reject(new Error("Receiving end does not exist"))
+            : Promise.resolve()
+        }
+        // healthCheck forwarded to the chosen tab → reply with success.
+        if (msg?.command === "healthCheck") {
+          setTimeout(() => {
+            dispatchMessage(
+              {
+                app: APP_ID,
+                action: "gptkResult",
+                command: "healthCheck",
+                requestId: msg.requestId,
+                success: true,
+                data: { hasGptk: true, hasWizData: true },
+              },
+              gpSender(reachableId)
+            )
+          }, 0)
+        }
+        return Promise.resolve()
+      }
+    )
+
+    dispatchMessage({ app: APP_ID, action: "healthCheck" }, appSender())
+    await new Promise((r) => setTimeout(r, 30))
+
+    // Command went to the reachable tab, never to the unreachable one.
+    expect(mockChrome.tabs.sendMessage).toHaveBeenCalledWith(
+      reachableId,
+      expect.objectContaining({ command: "healthCheck" })
+    )
+    expect(mockChrome.tabs.sendMessage).not.toHaveBeenCalledWith(
+      unreachableId,
+      expect.objectContaining({ command: "healthCheck" })
+    )
+    // And the app tab sees a successful connection.
+    expect(mockChrome.tabs.sendMessage).toHaveBeenCalledWith(
+      appTabId,
+      expect.objectContaining({ action: "healthCheck.result", success: true })
+    )
+  })
+
+  it("prefers the active tab over a more-recently-accessed inactive one", async () => {
+    const activeId = 41
+    const inactiveId = 42
+    const appTabId = 43
+
+    mockChrome.tabs.query.mockImplementation((query: { url?: string }) => {
+      if (query?.url?.includes("photos.google.com"))
+        return Promise.resolve([
+          { id: inactiveId, active: false, lastAccessed: 999 },
+          { id: activeId, active: true, lastAccessed: 1 },
+        ])
+      return Promise.resolve([{ id: appTabId }])
+    })
+    // Both tabs reachable — selection comes down purely to ordering.
+    mockChrome.tabs.sendMessage.mockResolvedValue(undefined)
+
+    dispatchMessage({ app: APP_ID, action: "healthCheck" }, appSender())
+    await new Promise((r) => setTimeout(r, 20))
+
+    // The first (and only) ping hits the active tab; the inactive one is
+    // never probed because the active tab answers first.
+    const pings = pingCalls()
+    expect(pings[0][0]).toBe(activeId)
+    expect(mockChrome.tabs.sendMessage).toHaveBeenCalledWith(
+      activeId,
+      expect.objectContaining({ command: "healthCheck" })
+    )
+  })
+
+  it("reports failure when no Google Photos tab has the bridge loaded", async () => {
+    const tabA = 51
+    const tabB = 52
+    const appTabId = 53
+
+    mockChrome.tabs.query.mockImplementation((query: { url?: string }) => {
+      if (query?.url?.includes("photos.google.com"))
+        return Promise.resolve([
+          { id: tabA, active: false, lastAccessed: 2 },
+          { id: tabB, active: false, lastAccessed: 1 },
+        ])
+      return Promise.resolve([{ id: appTabId }])
+    })
+    // Every ping rejects → no reachable bridge anywhere.
+    mockChrome.tabs.sendMessage.mockImplementation(
+      (_tabId: number, msg: { action?: string }) => {
+        if (msg?.action === "ping")
+          return Promise.reject(new Error("no bridge"))
+        return Promise.resolve()
+      }
+    )
+
+    dispatchMessage({ app: APP_ID, action: "healthCheck" }, appSender())
+    await new Promise((r) => setTimeout(r, 30))
+
+    // Both candidates were probed before giving up.
+    const pingedIds = pingCalls().map((c: unknown[]) => c[0])
+    expect(pingedIds).toContain(tabA)
+    expect(pingedIds).toContain(tabB)
+    // App tab is told it cannot connect.
+    expect(mockChrome.tabs.sendMessage).toHaveBeenCalledWith(
+      appTabId,
+      expect.objectContaining({ action: "healthCheck.result", success: false })
+    )
+  })
+})
+
+// ============================================================
 // gptkCommand routing
 // ============================================================
 

--- a/tests/commands/google-photos-commands.test.ts
+++ b/tests/commands/google-photos-commands.test.ts
@@ -344,3 +344,63 @@ describe("integration: trashItems full flow", () => {
     restore()
   })
 })
+
+// ============================================================
+// getAllMediaItems — per-page timeout (PR #122)
+//
+// Google's pagination endpoint occasionally hangs without ever rejecting
+// fetch(), which used to lock the UI on "Fetching media items" forever.
+// withTimeout() races each page against a 60s timer so a stall surfaces as a
+// real error instead of an indefinite hang.
+// ============================================================
+
+describe("getAllMediaItems — page timeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    delete (window as any).gptkApi
+  })
+
+  it("surfaces a timeout error when a page fetch never resolves", async () => {
+    ;(window as any).gptkApi = {
+      // Never resolves — simulates Google's pagination endpoint hanging.
+      getItemsByUploadedDate: vi.fn(() => new Promise(() => {})),
+    }
+
+    const { messages, restore } = collectMessages()
+    sendCommand("getAllMediaItems", "req-timeout-1", {})
+
+    // Advance past the 60s per-page timeout to trip the withTimeout race.
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    const result = messages.find(
+      (m: any) => m.action === "gptkResult" && m.command === "getAllMediaItems"
+    ) as any
+    expect(result?.success).toBe(false)
+    expect(result?.error).toMatch(/timed out/i)
+    restore()
+  })
+
+  it("does not error when the page resolves before the timeout fires", async () => {
+    ;(window as any).gptkApi = {
+      getItemsByUploadedDate: vi
+        .fn()
+        .mockResolvedValue({ items: [], nextPageId: null }),
+    }
+
+    const { messages, restore } = collectMessages()
+    sendCommand("getAllMediaItems", "req-timeout-2", {})
+
+    // Flush microtasks (no real delay needed — the page resolves immediately).
+    await vi.advanceTimersByTimeAsync(0)
+
+    const result = messages.find(
+      (m: any) => m.action === "gptkResult" && m.command === "getAllMediaItems"
+    ) as any
+    expect(result?.success).toBe(true)
+    restore()
+  })
+})

--- a/tests/components/duplicate-groups.test.tsx
+++ b/tests/components/duplicate-groups.test.tsx
@@ -120,6 +120,55 @@ describe("DuplicateGroups — chip rendering", () => {
 })
 
 // ============================================================
+// Group header item-kind label (PR #121)
+// ============================================================
+
+describe("DuplicateGroups — group item-kind label", () => {
+  const video = (k: string): GpdMediaItem => ({ ...makeItem(k), duration: 5000 })
+
+  /** Render a single group built from the given media-item map + key order. */
+  function renderGroup(items: Record<string, GpdMediaItem>, keys: string[]) {
+    wrap(
+      <DuplicateGroups
+        {...defaultProps}
+        groups={[makeGroup("gk", ...keys)]}
+        mediaItems={items}
+        selectedGroupIds={new Set(["gk"])}
+        keptByGroupId={new Map([["gk", new Set([keys[0]])]])}
+      />
+    )
+  }
+
+  it('labels an all-photo group "N photos"', () => {
+    renderGroup(
+      { a: makeItem("a"), b: makeItem("b"), c: makeItem("c") },
+      ["a", "b", "c"]
+    )
+    expect(screen.getByText(/^3 photos$/)).toBeInTheDocument()
+  })
+
+  it('labels a single-photo group "1 photo" (singular)', () => {
+    renderGroup({ a: makeItem("a") }, ["a"])
+    expect(screen.getByText(/^1 photo$/)).toBeInTheDocument()
+  })
+
+  it('labels an all-video group "N videos"', () => {
+    renderGroup({ a: video("a"), b: video("b") }, ["a", "b"])
+    expect(screen.getByText(/^2 videos$/)).toBeInTheDocument()
+  })
+
+  it('labels a single-video group "1 video" (singular)', () => {
+    renderGroup({ a: video("a") }, ["a"])
+    expect(screen.getByText(/^1 video$/)).toBeInTheDocument()
+  })
+
+  it('falls back to the neutral "items" for a mixed photo + video group', () => {
+    renderGroup({ a: makeItem("a"), b: video("b") }, ["a", "b"])
+    expect(screen.getByText(/^2 items$/)).toBeInTheDocument()
+  })
+})
+
+// ============================================================
 // Card click → onToggleKept
 // ============================================================
 

--- a/tests/components/scan-config.test.tsx
+++ b/tests/components/scan-config.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Component tests for ScanConfig — smart-mode time window (PR #121).
+ *
+ * Covers the `formatWindow` label formatter (s / m / h / d / w boundaries) and
+ * the time-window ToggleButtonGroup, which is only shown in smart mode and
+ * drives `onSettingsChange({ smartWindowSec })`.
+ */
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { ThemeProvider, createTheme } from "@mui/material/styles"
+import { ScanConfig } from "../../components/ScanConfig"
+import type { ScanSettings } from "../../lib/types"
+
+// ============================================================
+// Helpers
+// ============================================================
+
+const theme = createTheme()
+
+function renderConfig(settings: Partial<ScanSettings> = {}) {
+  const onSettingsChange = vi.fn()
+  const full: ScanSettings = {
+    similarityThreshold: 0.99,
+    scanMode: "smart",
+    smartWindowSec: 1,
+    ...settings,
+  }
+  render(
+    <ThemeProvider theme={theme}>
+      <ScanConfig
+        settings={full}
+        onSettingsChange={onSettingsChange}
+        onStartScan={vi.fn()}
+        hasGptk={true}
+      />
+    </ThemeProvider>
+  )
+  return { onSettingsChange }
+}
+
+// ============================================================
+// formatWindow — label formatting via the rendered "Time window:" line
+// ============================================================
+
+describe("ScanConfig — time window label (formatWindow)", () => {
+  // [smartWindowSec, expected label suffix]
+  const cases: [number, string][] = [
+    [1, "1s"],
+    [59, "59s"],
+    [60, "1m"],
+    [120, "2m"],
+    [3600, "1h"],
+    [7200, "2h"],
+    [86400, "1d"],
+    [172800, "2d"],
+    [604800, "1w"],
+    [1209600, "2w"],
+  ]
+
+  for (const [sec, label] of cases) {
+    it(`formats ${sec}s as "${label}"`, () => {
+      renderConfig({ smartWindowSec: sec })
+      expect(screen.getByText(/Time window:/)).toHaveTextContent(
+        `Time window: ${label}`
+      )
+    })
+  }
+
+  it("falls back to 1s when smartWindowSec is undefined", () => {
+    renderConfig({ smartWindowSec: undefined })
+    expect(screen.getByText(/Time window:/)).toHaveTextContent("Time window: 1s")
+  })
+})
+
+// ============================================================
+// Time window toggle — only shown in smart mode, fires onSettingsChange
+// ============================================================
+
+describe("ScanConfig — time window toggle", () => {
+  it("emits the selected window in seconds when a button is clicked", () => {
+    // smartWindowSec=1 → the "Time window:" label reads "1s", so the "1m"
+    // text uniquely identifies the toggle button (not the label).
+    const { onSettingsChange } = renderConfig({ smartWindowSec: 1 })
+    fireEvent.click(screen.getByText("1m"))
+    expect(onSettingsChange).toHaveBeenCalledWith({ smartWindowSec: 60 })
+  })
+
+  it("maps the 1w button to 604800 seconds", () => {
+    const { onSettingsChange } = renderConfig({ smartWindowSec: 1 })
+    fireEvent.click(screen.getByText("1w"))
+    expect(onSettingsChange).toHaveBeenCalledWith({ smartWindowSec: 604800 })
+  })
+
+  it("does not render the time window control in full-scan mode", () => {
+    renderConfig({ scanMode: "full" })
+    expect(screen.queryByText(/Time window:/)).not.toBeInTheDocument()
+  })
+})

--- a/tests/lib/duplicate-detector.test.ts
+++ b/tests/lib/duplicate-detector.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { communityDetection, matMul, topK, groupByTimestamp, withinGroupDuplicates, selectDefaultKeep } from "../../lib/duplicate-detector"
+import { communityDetection, matMul, topK, groupByTimestamp, withinGroupDuplicates, selectDefaultKeep, fullDetectDuplicates } from "../../lib/duplicate-detector"
 import type { GpdMediaItem } from "../../lib/types"
 
 // ============================================================
@@ -212,6 +212,7 @@ function makeItem(
   mediaKey: string,
   timestamp: number,
   creationTimestamp = 0,
+  extra: Partial<GpdMediaItem> = {},
 ): GpdMediaItem {
   return {
     mediaKey,
@@ -219,8 +220,46 @@ function makeItem(
     thumb: `https://example.com/${mediaKey}`,
     timestamp,
     creationTimestamp,
+    ...extra,
   }
 }
+
+// ============================================================
+// fullDetectDuplicates — candidate filtering (PR #121)
+//
+// Videos used to be excluded from scanning (`item.thumb && !item.duration`).
+// PR #121 changed the filter to `item.thumb` so two copies of the same clip —
+// which share an identical poster frame — get caught. These tests assert the
+// filter via the early-return path (< 2 candidates), which reports the count
+// in `timing.candidates` without touching the embedding model or IndexedDB.
+// ============================================================
+
+describe("fullDetectDuplicates — candidate filtering", () => {
+  it("includes a video (item with duration) as a candidate", async () => {
+    const video = makeItem("vid", 1000, 0, { duration: 5000 })
+    const { groups, timing } = await fullDetectDuplicates([video], 0.99)
+    // Single candidate → early return, but it was counted (not filtered out).
+    expect(timing.candidates).toBe(1)
+    expect(timing.totalItems).toBe(1)
+    expect(groups).toEqual([])
+  })
+
+  it("excludes items without a thumbnail", async () => {
+    const noThumb = makeItem("noThumb", 1000, 0, { thumb: undefined })
+    const { timing } = await fullDetectDuplicates([noThumb], 0.99)
+    expect(timing.candidates).toBe(0)
+    expect(timing.totalItems).toBe(1)
+  })
+
+  it("keeps the video but drops the thumbless item", async () => {
+    const video = makeItem("video", 1000, 0, { duration: 3000 })
+    const noThumb = makeItem("noThumb", 1000, 0, { thumb: undefined })
+    const { timing } = await fullDetectDuplicates([video, noThumb], 0.99)
+    // Only the video survives the filter → 1 candidate, still early-return.
+    expect(timing.candidates).toBe(1)
+    expect(timing.totalItems).toBe(2)
+  })
+})
 
 // ============================================================
 // groupByTimestamp


### PR DESCRIPTION
## Summary

Audited recently merged PRs #120–#123 for test coverage gaps and added tests for the core logic that shipped untested. **20 new tests; full suite green at 216 passing.**

| Area | PR | Coverage added |
|------|-----|---------------|
| `duplicate-detector` | #121 | Video items (with `duration`) now count as scan candidates; thumbless items still excluded. Asserted via the `<2`-candidate early return (`timing.candidates`) so no embedding model / IndexedDB is exercised. |
| `scan-config` *(new file)* | #121 | `formatWindow` s/m/h/d/w boundaries (+ undefined fallback); time-window toggle emits `smartWindowSec`; control hidden in full-scan mode. |
| `duplicate-groups` | #121 | `groupItemKind` label: photo/photos/video/videos, mixed→"items", singular/plural. |
| `google-photos-commands` | #122 | `withTimeout` surfaces a timeout error when a page fetch hangs (fake timers); stays clean when it resolves in time. |
| `service-worker` | #120 | `findGooglePhotosTab` skips unreachable tabs via ping fall-through, prefers the active tab, and reports failure when no bridge is reachable. |

## Not included

- **#123 (Fullscreen shortcuts)** — already well-covered by the 13-test suite that shipped with that PR.
- **#122 healthCheck retry/backoff** — only meaningfully testable as a timing-dependent `chrome.runtime` E2E case (the same flake profile recently removed from `cross-tab-messaging.test.ts`). Deferred as an opt-in follow-up.

## Verification

- `npm test` → **216 passed (13 files)**
- `tsc --noEmit` clean for app/test code (pre-existing errors only in the `Google-Photos-Toolkit/` submodule).