### PR TITLE
Add filter "Only from specific Album(s)"

### DIFF
--- a/components/ScanConfig.tsx
+++ b/components/ScanConfig.tsx
@@ -1,9 +1,20 @@
+import { useState, useEffect } from "react"
+import Avatar from "@mui/material/Avatar"
+import Checkbox from "@mui/material/Checkbox"
+import CircularProgress from "@mui/material/CircularProgress"
+import FormControlLabel from "@mui/material/FormControlLabel"
+import List from "@mui/material/List"
+import ListItem from "@mui/material/ListItem"
+import ListItemAvatar from "@mui/material/ListItemAvatar"
+import ListItemButton from "@mui/material/ListItemButton"
+import ListItemText from "@mui/material/ListItemText"
 import Accordion from "@mui/material/Accordion"
 import AccordionDetails from "@mui/material/AccordionDetails"
 import AccordionSummary from "@mui/material/AccordionSummary"
 import Alert from "@mui/material/Alert"
 import Box from "@mui/material/Box"
 import Button from "@mui/material/Button"
+import IconButton from "@mui/material/IconButton"
 import Paper from "@mui/material/Paper"
 import Slider from "@mui/material/Slider"
 import ToggleButton from "@mui/material/ToggleButton"
@@ -12,7 +23,9 @@ import Typography from "@mui/material/Typography"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import SearchRoundedIcon from "@mui/icons-material/SearchRounded"
 import WarningAmberRoundedIcon from "@mui/icons-material/WarningAmberRounded"
-import type { ScanSettings } from "../lib/types"
+import RefreshRoundedIcon from "@mui/icons-material/RefreshRounded"
+import type { ScanSettings, GptkAlbum, AppMessage, GptkResultMessage } from "../lib/types"
+import { APP_ID } from "../lib/types"
 
 function formatWindow(sec: number): string {
   if (sec < 60) return `${sec}s`
@@ -35,6 +48,56 @@ export function ScanConfig({
   onStartScan,
   hasGptk,
 }: ScanConfigProps) {
+  const [albums, setAlbums] = useState<GptkAlbum[] | null>(null)
+  const [isFetchingAlbums, setIsFetchingAlbums] = useState(false)
+  const [albumError, setAlbumError] = useState<string | null>(null)
+  const [scanError, setScanError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setScanError(null)
+  }, [settings.onlyFromAlbums, settings.albumMediaKeys])
+
+  useEffect(() => {
+    if (settings.onlyFromAlbums && !albums) {
+      setIsFetchingAlbums(true)
+      setAlbumError(null)
+      const requestId = `${Date.now()}-albums`
+
+      const listener = (message: AppMessage) => {
+        if (message?.app !== APP_ID) return
+        if (message.action === "gptkResult" && (message as GptkResultMessage).command === "getAlbums") {
+          const result = message as GptkResultMessage
+          if (result.requestId !== requestId) return
+          if (result.success) {
+            setAlbums(result.data as GptkAlbum[])
+          } else {
+            setAlbumError(result.error || "Failed to load albums")
+          }
+          setIsFetchingAlbums(false)
+          chrome.runtime.onMessage.removeListener(listener)
+        }
+      }
+      chrome.runtime.onMessage.addListener(listener)
+
+      chrome.runtime.sendMessage({
+        app: APP_ID,
+        action: "gptkCommand",
+        command: "getAlbums",
+        requestId
+      })
+
+      return () => chrome.runtime.onMessage.removeListener(listener)
+    }
+  }, [settings.onlyFromAlbums, albums])
+
+  const handleToggleAlbum = (mediaKey: string) => {
+    const current = settings.albumMediaKeys || []
+    const next = current.includes(mediaKey)
+      ? current.filter((k) => k !== mediaKey)
+      : [...current, mediaKey]
+    onSettingsChange({ albumMediaKeys: next })
+  }
+
   if (!hasGptk) {
     return (
       <Box sx={{ maxWidth: 480, mx: "auto", p: 4 }}>
@@ -64,12 +127,25 @@ export function ScanConfig({
           AI-powered image comparison.
         </Typography>
 
+        {scanError && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {scanError}
+          </Alert>
+        )}
+
         <Button
           variant="contained"
           fullWidth
           size="large"
           startIcon={<SearchRoundedIcon />}
-          onClick={onStartScan}
+          onClick={() => {
+            if (settings.onlyFromAlbums && (!settings.albumMediaKeys || settings.albumMediaKeys.length === 0)) {
+              setScanError('Selected "Only from specific Album(s)" but no albums selected!')
+              return
+            }
+            setScanError(null)
+            onStartScan()
+          }}
           sx={{ mb: 2 }}>
           Scan Library
         </Button>
@@ -135,6 +211,88 @@ export function ScanConfig({
                 </Typography>
               </Box>
             )}
+
+            <Box sx={{ mb: 3 }}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={settings.onlyFromAlbums ?? false}
+                    onChange={(e) => {
+                      const checked = e.target.checked
+                      onSettingsChange({
+                        onlyFromAlbums: checked,
+                        ...(checked ? {} : { albumMediaKeys: [] })
+                      })
+                    }}
+                    size="small"
+                  />
+                }
+                label={
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                    <Typography variant="body2" fontWeight={500}>
+                      Only from specific Album(s)
+                    </Typography>
+                    {isFetchingAlbums && <CircularProgress size={16} />}
+                    {settings.onlyFromAlbums && !isFetchingAlbums && (
+                      <IconButton
+                        size="small"
+                        title="Refresh albums"
+                        onClick={(e) => {
+                          e.preventDefault()
+                          e.stopPropagation()
+                          setAlbums(null)
+                        }}
+                        sx={{ p: 0.5, ml: 0.5 }}
+                      >
+                        <RefreshRoundedIcon fontSize="small" />
+                      </IconButton>
+                    )}
+                  </Box>
+                }
+              />
+              
+              {settings.onlyFromAlbums && (
+                <Box sx={{ mt: 1, maxHeight: 300, overflowY: "auto", border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
+                  {albumError && (
+                    <Alert severity="error" sx={{ m: 1 }}>{albumError}</Alert>
+                  )}
+                  {albums && albums.length === 0 && (
+                    <Typography variant="body2" color="text.secondary" sx={{ p: 2, textAlign: "center" }}>
+                      No albums found.
+                    </Typography>
+                  )}
+                  {albums && albums.length > 0 && (
+                    <List dense disablePadding>
+                      {albums.map((album) => {
+                        const isChecked = (settings.albumMediaKeys || []).includes(album.mediaKey)
+                        return (
+                          <ListItem key={album.mediaKey} disablePadding>
+                            <ListItemButton onClick={() => handleToggleAlbum(album.mediaKey)}>
+                              <Checkbox
+                                edge="start"
+                                checked={isChecked}
+                                tabIndex={-1}
+                                disableRipple
+                                size="small"
+                              />
+                              <ListItemAvatar sx={{ minWidth: 40 }}>
+                                <Avatar src={album.thumb} variant="rounded" sx={{ width: 24, height: 24 }} />
+                              </ListItemAvatar>
+                              <ListItemText
+                                primary={album.title}
+                                secondary={`${album.itemCount} items`}
+                                primaryTypographyProps={{ variant: "body2", noWrap: true }}
+                                secondaryTypographyProps={{ variant: "caption" }}
+                              />
+                            </ListItemButton>
+                          </ListItem>
+                        )
+                      })}
+                    </List>
+                  )}
+                </Box>
+              )}
+            </Box>
 
             <Box>
               <Typography variant="body2" fontWeight={500} sx={{ mb: 1 }}>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -175,6 +175,13 @@ export interface DuplicateGroup {
   similarity: number; // average pairwise similarity in the group
 }
 
+export interface GptkAlbum {
+  mediaKey: string;
+  title: string;
+  thumb: string;
+  itemCount: number;
+}
+
 // ============================================================
 // Stored state (chrome.storage.local)
 // ============================================================
@@ -210,10 +217,15 @@ export interface ScanSettings {
     from?: string;
     to?: string;
   };
+  onlyFromAlbums?: boolean;
+  albumMediaKeys?: string[];
+  albumAccountEmail?: string;
 }
 
 export const DEFAULT_SETTINGS: ScanSettings = {
   similarityThreshold: 0.99,
   scanMode: "smart",
   smartWindowSec: 1,
+  onlyFromAlbums: false,
+  albumMediaKeys: [],
 };

--- a/scripts/google-photos-commands.js
+++ b/scripts/google-photos-commands.js
@@ -53,6 +53,94 @@ function chunkArray(arr, size) {
   return chunks
 }
 
+function mapMediaItem(item) {
+  return {
+    mediaKey: item.mediaKey,
+    dedupKey: item.dedupKey,
+    thumb: item.thumb,
+    timestamp: item.timestamp,
+    creationTimestamp: item.creationTimestamp,
+    resWidth: item.resWidth,
+    resHeight: item.resHeight,
+    duration: item.duration,
+    isOwned: item.isOwned,
+    isOriginalQuality: item.isOriginalQuality ?? null,
+    fileName: item.descriptionShort || null,
+    productUrl: "https://photos.google.com/photo/" + item.mediaKey
+  }
+}
+
+// ============================================================
+// Command: getAlbums
+// Fetches all albums from the library via GPTK pagination.
+// ============================================================
+
+// Per-page timeout. Google's pagination endpoint occasionally hangs without
+// ever rejecting fetch(), which used to lock the UI on "Fetching media
+// items" indefinitely. A timeout lets us surface a real error to the user.
+const PAGE_TIMEOUT_MS = 60_000
+
+function withTimeout(promise, ms, label) {
+  let timer
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          new Error(
+            `${label} timed out after ${Math.round(ms / 1000)}s. Google's API likely stalled — please re-scan.`
+          )
+        ),
+      ms
+    )
+  })
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
+}
+
+
+async function getAlbums(requestId) {
+  const gptkApi = window.gptkApi
+  if (!gptkApi) {
+    postError(
+      "getAlbums",
+      requestId,
+      "GPTK API not available. Reload the Google Photos page."
+    )
+    return
+  }
+
+  try {
+    let nextPageId = null
+    const albums = []
+
+    do {
+      const page = await withTimeout(
+        gptkApi.getAlbums(nextPageId),
+        PAGE_TIMEOUT_MS,
+        "Fetching albums from Google Photos"
+      )
+      if (!page) {
+        console.warn("GPD: Empty page response, stopping pagination")
+        break
+      }
+      if (page.items && page.items.length > 0) {
+        for (const album of page.items) {
+          albums.push({
+            mediaKey: album.mediaKey,
+            title: album.title,
+            thumb: album.thumb,
+            itemCount: album.itemCount
+          })
+        }
+      }
+      nextPageId = page.nextPageId || null
+    } while (nextPageId)
+
+    postResult("getAlbums", requestId, albums)
+  } catch (error) {
+    postError("getAlbums", requestId, error)
+  }
+}
+
 // ============================================================
 // Command: getAllMediaItems
 // Fetches all media items from the library via GPTK pagination.
@@ -73,78 +161,100 @@ async function getAllMediaItems(requestId, args) {
   const sinceTimestamp =
     args && args.sinceTimestamp ? args.sinceTimestamp : null
 
-  // Per-page timeout. Google's pagination endpoint occasionally hangs without
-  // ever rejecting fetch(), which used to lock the UI on "Fetching media
-  // items" indefinitely. A timeout lets us surface a real error to the user.
-  const PAGE_TIMEOUT_MS = 60_000
-
-  function withTimeout(promise, ms, label) {
-    let timer
-    const timeout = new Promise((_, reject) => {
-      timer = setTimeout(
-        () =>
-          reject(
-            new Error(
-              `${label} timed out after ${Math.round(ms / 1000)}s. Google's API likely stalled — please re-scan.`
-            )
-          ),
-        ms
-      )
-    })
-    return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
-  }
-
   try {
-    let nextPageId = null
     const mediaItems = []
-    let reachedCache = false
+    const albumKeys = (args && args.albumMediaKeys) ? args.albumMediaKeys : []
+    const isAlbumScan = albumKeys.length > 0
 
-    do {
-      const page = await withTimeout(
-        gptkApi.getItemsByUploadedDate(nextPageId),
-        PAGE_TIMEOUT_MS,
-        "Fetching page from Google Photos"
-      )
-      if (!page) {
-        console.warn("GPD: Empty page response, stopping pagination")
-        break
-      }
-      if (page.items && page.items.length > 0) {
-        for (const item of page.items) {
-          // Items are sorted newest-first — stop when we hit the cached watermark
-          if (
-            sinceTimestamp !== null &&
-            item.creationTimestamp <= sinceTimestamp
-          ) {
-            reachedCache = true
-            break
+    const dateRange = (args && args.dateRange) ? args.dateRange : null
+    const fromTs = dateRange?.from ? new Date(dateRange.from).getTime() : null
+    const toTs = dateRange?.to ? new Date(dateRange.to).getTime() : null
+
+    if (isAlbumScan) {
+      const seenKeys = new Set()
+      for (const albumMediaKey of albumKeys) {
+        let nextPageId = null
+        do {
+          let page = null;
+          let retries = 0;
+          const MAX_RETRIES = 3;
+          while (true) {
+            try {
+              page = await withTimeout(
+                gptkApi.getAlbumPage(albumMediaKey, nextPageId),
+                PAGE_TIMEOUT_MS,
+                "Fetching album page from Google Photos"
+              )
+              if (!page) {
+                throw new Error("Empty page response from Google Photos API");
+              }
+              break; // Success
+            } catch (error) {
+              if (retries >= MAX_RETRIES) {
+                throw new Error(`Failed to fetch album ${albumMediaKey} after ${MAX_RETRIES} retries: ${error.message}`);
+              }
+              retries++;
+              console.warn(`GPD: Error fetching album page, retrying (${retries}/${MAX_RETRIES}):`, error);
+              await new Promise(r => setTimeout(r, 1000));
+            }
           }
-          mediaItems.push({
-            mediaKey: item.mediaKey,
-            dedupKey: item.dedupKey,
-            thumb: item.thumb,
-            timestamp: item.timestamp,
-            creationTimestamp: item.creationTimestamp,
-            resWidth: item.resWidth,
-            resHeight: item.resHeight,
-            duration: item.duration,
-            isOwned: item.isOwned,
-            isOriginalQuality: item.isOriginalQuality ?? null,
-            fileName: item.descriptionShort || null,
-            productUrl: "https://photos.google.com/photo/" + item.mediaKey
-          })
-        }
+          if (page.items && page.items.length > 0) {
+            for (const item of page.items) {
+              if (seenKeys.has(item.mediaKey)) continue
+              if (fromTs !== null && item.timestamp < fromTs) continue
+              if (toTs !== null && item.timestamp > toTs) continue
+              seenKeys.add(item.mediaKey)
+              mediaItems.push(mapMediaItem(item))
+            }
+          }
+          nextPageId = page.nextPageId || null
+
+          postProgress(
+            requestId,
+            mediaItems.length,
+            `Fetched ${mediaItems.length} items from albums`
+          )
+        } while (nextPageId)
       }
-      nextPageId = page.nextPageId || null
+    } else {
+      let reachedCache = false
+      let nextPageId = null
+      do {
+        const page = await withTimeout(
+          gptkApi.getItemsByUploadedDate(nextPageId),
+          PAGE_TIMEOUT_MS,
+          "Fetching page from Google Photos"
+        )
+        if (!page) {
+          console.warn("GPD: Empty page response, stopping pagination")
+          break
+        }
+        if (page.items && page.items.length > 0) {
+          for (const item of page.items) {
+            // Items are sorted newest-first — stop when we hit the cached watermark
+            if (
+              sinceTimestamp !== null &&
+              item.creationTimestamp <= sinceTimestamp
+            ) {
+              reachedCache = true
+              break
+            }
+            if (fromTs !== null && item.timestamp < fromTs) continue
+            if (toTs !== null && item.timestamp > toTs) continue
+            mediaItems.push(mapMediaItem(item))
+          }
+        }
+        nextPageId = page.nextPageId || null
 
-      postProgress(
-        requestId,
-        mediaItems.length,
-        `Fetched ${mediaItems.length} items`
-      )
+        postProgress(
+          requestId,
+          mediaItems.length,
+          `Fetched ${mediaItems.length} items`
+        )
 
-      if (reachedCache) break
-    } while (nextPageId)
+        if (reachedCache) break
+      } while (nextPageId)
+    }
 
     postResult("getAllMediaItems", requestId, mediaItems)
   } catch (error) {
@@ -285,6 +395,9 @@ window.addEventListener("message", async (event) => {
   console.log("GPD: Received command", command, requestId)
 
   switch (command) {
+    case "getAlbums":
+      await getAlbums(requestId)
+      break
     case "getAllMediaItems":
       await getAllMediaItems(requestId, args)
       break

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -125,6 +125,10 @@ export default function App() {
   // scans killed by reload can be dropped (they arrive late from the GP tab)
   const currentScanRequestIdRef = useRef<string | null>(null)
 
+  // Tracks whether the active scan targets specific albums (vs full library).
+  // Album scans must not overwrite the main library media-items cache.
+  const isAlbumScanRef = useRef(false)
+
   // Counts failed healthCheck attempts during initial connect so we can retry
   // silently before showing a disconnected error.
   const healthCheckAttemptsRef = useRef(0)
@@ -310,6 +314,17 @@ export default function App() {
     return () => chrome.runtime.onMessage.removeListener(listener)
   }, [])
 
+  const currentAccountEmail = "accountEmail" in state ? state.accountEmail : undefined;
+  useEffect(() => {
+    if (currentAccountEmail) {
+      if (settings.albumAccountEmail && currentAccountEmail !== settings.albumAccountEmail) {
+        setSettings({ albumMediaKeys: [], onlyFromAlbums: false, albumAccountEmail: currentAccountEmail });
+      } else if (!settings.albumAccountEmail) {
+        setSettings({ albumAccountEmail: currentAccountEmail });
+      }
+    }
+  }, [currentAccountEmail, settings.albumAccountEmail]);
+
   // Keep refs so async callbacks always see latest values
   const settingsRef = useRef(settings)
   settingsRef.current = settings
@@ -485,6 +500,9 @@ export default function App() {
   const accountEmailForStorage = state.status === "results" ? state.accountEmail : undefined
   useEffect(() => {
     if (!mediaItems) return
+    // Album scan results must not overwrite the main library cache —
+    // they contain only a subset of items and would break incremental fetching.
+    if (isAlbumScanRef.current) return
     if (groups.length > 0) {
       const newestCreationTimestamp = Object.values(mediaItems).reduce(
         (max, item) => Math.max(max, item.creationTimestamp ?? 0),
@@ -509,6 +527,7 @@ export default function App() {
   // Persist selections when they change (only while results are showing)
   useEffect(() => {
     if (state.status !== "results") return
+    if (isAlbumScanRef.current) return
     if (groups.length === 0) {
       chrome.storage.local.remove("selections")
       return
@@ -541,40 +560,47 @@ export default function App() {
       currentState.status === "connected" || currentState.status === "results"
         ? currentState.accountEmail
         : undefined
+    const isAlbumScan = !!(settings.onlyFromAlbums && settings.albumMediaKeys?.length)
+    isAlbumScanRef.current = isAlbumScan
+
     dispatch({ type: "SCAN_STARTED", requestId, hasGptk, accountEmail })
 
     console.log(
-      `[GPD] starting scan: mode=${settings.scanMode}, threshold=${settings.similarityThreshold}`
+      `[GPD] starting scan: mode=${settings.scanMode}, threshold=${settings.similarityThreshold}, albumScan=${isAlbumScan}`
     )
 
     // Load cached media items for incremental fetch. On a repeat scan we only
     // fetch items newer than the most-recently-seen upload timestamp.
+    // Skip for album scans — album items must not pollute the main library
+    // cache, and incremental fetching doesn't apply to album queries.
     cachedMediaItemsRef.current = null
     let sinceTimestamp: number | undefined
-    try {
-      const stored = (await chrome.storage.local.get(
-        "scanResults"
-      )) as Partial<StoredState>
-      const prev = stored.scanResults
-      if (
-        prev?.mediaItems &&
-        Object.keys(prev.mediaItems).length > 0 &&
-        areScanResultsValid(prev, { accountEmail })
-      ) {
-        cachedMediaItemsRef.current = prev.mediaItems
-        // Compute watermark if not stored (migration: first run after this deploy)
-        sinceTimestamp =
-          prev.newestCreationTimestamp ??
-          Object.values(prev.mediaItems).reduce(
-            (max, item) => Math.max(max, item.creationTimestamp ?? 0),
-            0
+    if (!isAlbumScan) {
+      try {
+        const stored = (await chrome.storage.local.get(
+          "scanResults"
+        )) as Partial<StoredState>
+        const prev = stored.scanResults
+        if (
+          prev?.mediaItems &&
+          Object.keys(prev.mediaItems).length > 0 &&
+          areScanResultsValid(prev, { accountEmail })
+        ) {
+          cachedMediaItemsRef.current = prev.mediaItems
+          // Compute watermark if not stored (migration: first run after this deploy)
+          sinceTimestamp =
+            prev.newestCreationTimestamp ??
+            Object.values(prev.mediaItems).reduce(
+              (max, item) => Math.max(max, item.creationTimestamp ?? 0),
+              0
+            )
+          console.log(
+            `[GPD] media items cache: ${Object.keys(prev.mediaItems).length} items, fetching since ${new Date(sinceTimestamp).toISOString()}`
           )
-        console.log(
-          `[GPD] media items cache: ${Object.keys(prev.mediaItems).length} items, fetching since ${new Date(sinceTimestamp).toISOString()}`
-        )
+        }
+      } catch {
+        // Cache unavailable — do full fetch
       }
-    } catch {
-      // Cache unavailable — do full fetch
     }
 
     sendToServiceWorker({
@@ -584,7 +610,8 @@ export default function App() {
       requestId,
       args: {
         dateRange: settings.dateRange,
-        sinceTimestamp
+        sinceTimestamp,
+        albumMediaKeys: isAlbumScan ? settings.albumMediaKeys : undefined
       }
     })
   }, [settings])

--- a/tests/commands/google-photos-commands.test.ts
+++ b/tests/commands/google-photos-commands.test.ts
@@ -87,8 +87,159 @@ afterEach(() => {
 })
 
 // ============================================================
+// Unit tests: getAlbums
+// ============================================================
+
+describe("getAlbums", () => {
+  it("fetches and maps albums", async () => {
+    ;(window as any).gptkApi = {
+      getAlbums: vi.fn().mockResolvedValue({
+        items: [
+          { mediaKey: "a1", title: "Album 1", thumb: "http://thumb/1", itemCount: 10 },
+          { mediaKey: "a2", title: "Album 2", thumb: "http://thumb/2", itemCount: 20 }
+        ],
+        nextPageId: null
+      }),
+    }
+
+    const { messages, restore } = collectMessages()
+    sendCommand("getAlbums", "req-alb-1", {})
+    await flush()
+
+    const result = messages.find(
+      (m: any) => m.action === "gptkResult" && m.command === "getAlbums"
+    ) as any
+    expect(result?.success).toBe(true)
+    expect(result?.data).toHaveLength(2)
+    expect(result?.data[0].title).toBe("Album 1")
+    restore()
+    delete (window as any).gptkApi
+  })
+})
+
+// ============================================================
 // Unit tests: getAllMediaItems
 // ============================================================
+
+describe("getAllMediaItems — album fetching", () => {
+  it("fetches items from provided albumMediaKeys and deduplicates by mediaKey", async () => {
+    ;(window as any).gptkApi = {
+      getAlbumPage: vi.fn().mockImplementation((albumKey) => {
+        if (albumKey === "album1") {
+          return Promise.resolve({
+            items: [
+              { mediaKey: "mk1", dedupKey: "dk1", thumb: "th1", timestamp: 1000, creationTimestamp: 2000, resWidth: 1920, resHeight: 1080, isOwned: true, isOriginalQuality: true, descriptionShort: "file1.jpg" },
+              { mediaKey: "mk2", dedupKey: "dk2", thumb: "th2", timestamp: 1001, creationTimestamp: 2001, resWidth: 1920, resHeight: 1080, isOwned: true, isOriginalQuality: true, descriptionShort: "file2.jpg" }
+            ],
+            nextPageId: null
+          })
+        }
+        if (albumKey === "album2") {
+          return Promise.resolve({
+            items: [
+              { mediaKey: "mk2", dedupKey: "dk2", thumb: "th2", timestamp: 1001, creationTimestamp: 2001, resWidth: 1920, resHeight: 1080, isOwned: true, isOriginalQuality: true, descriptionShort: "file2.jpg" }, // Duplicate
+              { mediaKey: "mk3", dedupKey: "dk3", thumb: "th3", timestamp: 1002, creationTimestamp: 2002, resWidth: 1920, resHeight: 1080, isOwned: true, isOriginalQuality: false, descriptionShort: "file3.jpg" }
+            ],
+            nextPageId: null
+          })
+        }
+      })
+    }
+
+    const { messages, restore } = collectMessages()
+    sendCommand("getAllMediaItems", "req-alb-2", { albumMediaKeys: ["album1", "album2"] })
+    await flush()
+
+    const result = messages.find(
+      (m: any) => m.action === "gptkResult" && m.command === "getAllMediaItems"
+    ) as any
+    
+    expect(result?.success).toBe(true)
+    // Should have 3 unique items
+    expect(result?.data).toHaveLength(3)
+    expect(result?.data.map((i: any) => i.mediaKey)).toEqual(["mk1", "mk2", "mk3"])
+    restore()
+    delete (window as any).gptkApi
+  })
+
+  it("retries fetching an album page upon failure and succeeds", async () => {
+    vi.useFakeTimers()
+    let attempts = 0
+    ;(window as any).gptkApi = {
+      getAlbumPage: vi.fn().mockImplementation((albumKey) => {
+        attempts++
+        if (attempts <= 2) {
+          // Fail the first two times
+          return Promise.reject(new Error("Network Error"))
+        }
+        // Succeed on the third try
+        return Promise.resolve({
+          items: [
+            { mediaKey: "mk1", dedupKey: "dk1", thumb: "th1", timestamp: 1000, creationTimestamp: 2000, resWidth: 1920, resHeight: 1080, isOwned: true, isOriginalQuality: true, descriptionShort: "file1.jpg" }
+          ],
+          nextPageId: null
+        })
+      })
+    }
+
+    const { messages, restore } = collectMessages()
+    try {
+      sendCommand("getAllMediaItems", "req-alb-retry-success", { albumMediaKeys: ["album1"] })
+      
+      // Advance timers to trigger the retries without using flush()
+      await vi.advanceTimersByTimeAsync(10)
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(1000)
+
+      const result = messages.find(
+        (m: any) => m.action === "gptkResult" && m.command === "getAllMediaItems"
+      ) as any
+      
+      expect(result?.success).toBe(true)
+      expect(result?.data).toHaveLength(1)
+      expect(attempts).toBe(3)
+    } finally {
+      restore()
+      delete (window as any).gptkApi
+      vi.useRealTimers()
+    }
+  })
+
+  it("fails after maximum retries when fetching an album page", async () => {
+    vi.useFakeTimers()
+    let attempts = 0
+    ;(window as any).gptkApi = {
+      getAlbumPage: vi.fn().mockImplementation((albumKey) => {
+        attempts++
+        return Promise.resolve(null) // Simulates an empty payload, which triggers retry
+      })
+    }
+
+    const { messages, restore } = collectMessages()
+    try {
+      sendCommand("getAllMediaItems", "req-alb-retry-fail", { albumMediaKeys: ["album1"] })
+      
+      // Advance timers three times for the 3 retries
+      for (let i = 0; i < 4; i++) {
+        await vi.advanceTimersByTimeAsync(10)
+        await vi.advanceTimersByTimeAsync(1000)
+      }
+
+      const result = messages.find(
+        (m: any) => m.action === "gptkResult" && m.command === "getAllMediaItems"
+      ) as any
+      
+      expect(result?.success).toBe(false)
+      expect(result?.error).toMatch(/after 3 retries/i)
+      // 1 initial try + 3 retries = 4 attempts total
+      expect(attempts).toBe(4)
+    } finally {
+      restore()
+      delete (window as any).gptkApi
+      vi.useRealTimers()
+    }
+  })
+})
 
 describe("getAllMediaItems — field mapping", () => {
   function setupGptkApi(items: unknown[], nextPageId: string | null = null) {
@@ -168,6 +319,72 @@ describe("getAllMediaItems — field mapping", () => {
       (m: any) => m.action === "gptkResult" && m.command === "getAllMediaItems"
     ) as any
     expect(result?.data[0].isOriginalQuality).toBeNull()
+    restore()
+  })
+})
+
+// ============================================================
+// Unit tests: getAllMediaItems — dateRange filtering
+// ============================================================
+
+describe("getAllMediaItems — dateRange filtering", () => {
+  const mk1 = { mediaKey: "mk1", timestamp: new Date("2021-01-01").getTime(), thumb: "th1" }
+  const mk2 = { mediaKey: "mk2", timestamp: new Date("2022-01-01").getTime(), thumb: "th2" }
+  const mk3 = { mediaKey: "mk3", timestamp: new Date("2023-01-01").getTime(), thumb: "th3" }
+
+  function setupGptkApi(items: unknown[]) {
+    ;(window as any).gptkApi = {
+      getItemsByUploadedDate: vi.fn().mockResolvedValue({ items, nextPageId: null }),
+      getAlbumPage: vi.fn().mockResolvedValue({ items, nextPageId: null }),
+    }
+  }
+
+  afterEach(() => {
+    delete (window as any).gptkApi
+  })
+
+  it("filters out items outside the dateRange (full scan)", async () => {
+    setupGptkApi([mk1, mk2, mk3])
+
+    const { messages, restore } = collectMessages()
+    sendCommand("getAllMediaItems", "req-date-1", {
+      dateRange: {
+        from: "2021-06-01T00:00:00.000Z",
+        to: "2022-06-01T00:00:00.000Z",
+      }
+    })
+    await flush()
+
+    const result = messages.find(
+      (m: any) => m.action === "gptkResult" && m.command === "getAllMediaItems"
+    ) as any
+    
+    expect(result?.success).toBe(true)
+    expect(result?.data).toHaveLength(1)
+    expect(result?.data[0].mediaKey).toBe("mk2")
+    restore()
+  })
+
+  it("filters out items outside the dateRange (album scan)", async () => {
+    setupGptkApi([mk1, mk2, mk3])
+
+    const { messages, restore } = collectMessages()
+    sendCommand("getAllMediaItems", "req-date-2", {
+      albumMediaKeys: ["album1"],
+      dateRange: {
+        from: "2021-06-01T00:00:00.000Z",
+        to: "2022-06-01T00:00:00.000Z",
+      }
+    })
+    await flush()
+
+    const result = messages.find(
+      (m: any) => m.action === "gptkResult" && m.command === "getAllMediaItems"
+    ) as any
+    
+    expect(result?.success).toBe(true)
+    expect(result?.data).toHaveLength(1)
+    expect(result?.data[0].mediaKey).toBe("mk2")
     restore()
   })
 })

--- a/tests/components/scan-config.test.tsx
+++ b/tests/components/scan-config.test.tsx
@@ -96,3 +96,31 @@ describe("ScanConfig — time window toggle", () => {
     expect(screen.queryByText(/Time window:/)).not.toBeInTheDocument()
   })
 })
+
+// ============================================================
+// Album Selection checkbox
+// ============================================================
+
+describe("ScanConfig — album selection", () => {
+  it("clears albumMediaKeys when Only from specific Album(s) is unchecked", () => {
+    vi.stubGlobal("chrome", {
+      runtime: {
+        onMessage: { addListener: vi.fn(), removeListener: vi.fn() },
+        sendMessage: vi.fn()
+      }
+    })
+
+    const { onSettingsChange } = renderConfig({ 
+      onlyFromAlbums: true,
+      albumMediaKeys: ["album1", "album2"]
+    })
+    
+    const checkbox = screen.getByRole("checkbox", { hidden: true })
+    fireEvent.click(checkbox)
+    
+    expect(onSettingsChange).toHaveBeenCalledWith({
+      onlyFromAlbums: false,
+      albumMediaKeys: []
+    })
+  })
+})

--- a/tests/e2e/integration/app-tab.test.ts
+++ b/tests/e2e/integration/app-tab.test.ts
@@ -12,6 +12,7 @@ import {
   injectScanResults,
   injectSelections,
   clearStorage,
+  openGptkStubPage,
 } from "../fixtures/extension"
 
 let context: BrowserContext
@@ -147,5 +148,62 @@ test("persists kept overrides through page reload", async () => {
   await expect(cards.nth(1)).toContainText("Keep")
 
   await page.close()
+  await clearStorage(context)
+})
+
+test("does not overwrite main library cache during album scans", async () => {
+  // Inject a full library cache first
+  await injectScanResults(
+    context,
+    [
+      { id: "g1", mediaKeys: ["key1", "key2"], originalMediaKey: "key1", similarity: 0.99 },
+    ],
+    BASE_MEDIA_ITEMS,
+    6
+  )
+
+  const gpPage = await openGptkStubPage(context, {
+    getAlbums: {
+      data: [{ mediaKey: "album1", title: "Test Album", itemCount: 2, thumb: "" }]
+    },
+    getAllMediaItems: {
+      data: [
+        { mediaKey: "album-item1", dedupKey: "d-album", thumb: "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=", timestamp: 0, creationTimestamp: 1, resWidth: 100, resHeight: 100, duration: null, isOwned: true, fileName: "a1.jpg" }
+      ]
+    }
+  })
+
+  const page = await openAppTab(context, extensionId)
+  await expect(page.getByText("1 Duplicate Group Found")).toBeVisible({ timeout: 5000 })
+
+  // Go back to scanning UI
+  await page.getByRole("button", { name: "Re-scan" }).click()
+
+  // Setup album scan
+  await page.getByText("More options").click()
+  await page.getByRole("checkbox", { name: /Only from specific Album/i }).check()
+  await expect(page.getByText("Test Album")).toBeVisible()
+  
+  // Actually click the list item button which contains the checkbox
+  await page.getByText("Test Album").click()
+  
+  await page.getByRole("button", { name: "Scan Library" }).click()
+
+  // wait for album scan to finish (1 item -> instant completion, 0 groups)
+  await expect(page.getByText("No duplicates found in your library.")).toBeVisible({ timeout: 5000 })
+
+  // assert storage
+  const scanResults = await page.evaluate((): Promise<any> => {
+    return new Promise((resolve) => {
+      chrome.storage.local.get("scanResults", (res) => resolve(res.scanResults))
+    })
+  })
+
+  // The album scan should not have overwritten the full library cache.
+  // It should still have 6 items from BASE_MEDIA_ITEMS, not 2 from the album.
+  expect(Object.keys(scanResults.mediaItems).length).toBe(6)
+
+  await page.close()
+  await gpPage.close()
   await clearStorage(context)
 })


### PR DESCRIPTION
Add ability to scan and deduplicate photos exclusively from user-selected Google Photos albums, rather than the entire library.

UI Changes: 
- Added an 'Only from specific Album(s)' checkbox that lazily fetches and renders the user's available albums for selection. REsult can be refreshed with

Backend:
- Added getAlbums API call to fetch a paginated list of albums (up to 3 retries).
- Modified getAllMediaItems to support fetching items by album and deduplicating by mediaKey. Even supported date filter which is missing from UI as of now.
- Isolated album scans from the main library cache to prevent album results from overwriting the full library's incremental fetch watermark (sinceTimestamp).
<img width="428" height="739" alt="image" src="https://github.com/user-attachments/assets/f8fc2aae-51d6-46a1-b3f5-f2f6e515032a" />


