### PR TITLE
Deduplicate media items by dedupKey

### DIFF
--- a/lib/duplicate-detector.ts
+++ b/lib/duplicate-detector.ts
@@ -29,6 +29,28 @@ export function selectDefaultKeep(items: GpdMediaItem[]): string {
   return best[0].mediaKey;
 }
 
+/**
+ * Deduplicate media items by dedupKey.
+ * There can be photos with different mediaKeys but same dedupKey,
+ * likely caused by saving shared albums.
+ * We should not solve for them, since
+ * - Google Photos natively collapses them into one in timeline/albums
+ * - API doesn't allow to trash one of them without trashing others
+ * So keep only the first item we see for each dedupKey.
+ */
+export function dropDuplicateDedupKeys(items: GpdMediaItem[]): GpdMediaItem[] {
+  const seen = new Set<string>();
+  const uniqueItems: GpdMediaItem[] = [];
+  for (const item of items) {
+    if (item.dedupKey) {
+      if (seen.has(item.dedupKey)) continue;
+      seen.add(item.dedupKey);
+    }
+    uniqueItems.push(item);
+  }
+  return uniqueItems;
+}
+
 const MODEL_URL =
   "https://storage.googleapis.com/mediapipe-models/image_embedder/mobilenet_v3_large/float32/latest/mobilenet_v3_large.tflite";
 
@@ -159,6 +181,8 @@ export async function fullDetectDuplicates(
   logger?: ScanLogger,
 ): Promise<{ groups: DuplicateGroup[]; timing: ScanTiming }> {
   const scanStart = performance.now();
+
+  mediaItems = dropDuplicateDedupKeys(mediaItems);
 
   // Filter to items with thumbnails (photos only, skip videos)
   // Include items with thumbnails. Video posters work too — two copies of the
@@ -466,6 +490,9 @@ export async function smartDetectDuplicates(
   logger?: ScanLogger,
 ): Promise<DuplicateGroup[]> {
   const scanStart = performance.now();
+
+  mediaItems = dropDuplicateDedupKeys(mediaItems);
+
   // Include items with thumbnails. Video posters work too — two copies of the
   // same clip have identical poster frames, which produce near-identical
   // embeddings.

--- a/lib/duplicate-detector.ts
+++ b/lib/duplicate-detector.ts
@@ -38,7 +38,7 @@ export function selectDefaultKeep(items: GpdMediaItem[]): string {
  * - API doesn't allow to trash one of them without trashing others
  * So keep only the first item we see for each dedupKey.
  */
-export function dropDuplicateDedupKeys(items: GpdMediaItem[]): GpdMediaItem[] {
+export function dedupeByDedupKey(items: GpdMediaItem[]): GpdMediaItem[] {
   const seen = new Set<string>();
   const uniqueItems: GpdMediaItem[] = [];
   for (const item of items) {
@@ -182,7 +182,7 @@ export async function fullDetectDuplicates(
 ): Promise<{ groups: DuplicateGroup[]; timing: ScanTiming }> {
   const scanStart = performance.now();
 
-  const dedupedItems = dropDuplicateDedupKeys(mediaItems);
+  const dedupedItems = dedupeByDedupKey(mediaItems);
 
   // Filter to items with thumbnails (photos only, skip videos)
   // Include items with thumbnails. Video posters work too — two copies of the
@@ -491,7 +491,7 @@ export async function smartDetectDuplicates(
 ): Promise<DuplicateGroup[]> {
   const scanStart = performance.now();
 
-  const dedupedItems = dropDuplicateDedupKeys(mediaItems);
+  const dedupedItems = dedupeByDedupKey(mediaItems);
 
   // Include items with thumbnails. Video posters work too — two copies of the
   // same clip have identical poster frames, which produce near-identical

--- a/lib/duplicate-detector.ts
+++ b/lib/duplicate-detector.ts
@@ -182,13 +182,13 @@ export async function fullDetectDuplicates(
 ): Promise<{ groups: DuplicateGroup[]; timing: ScanTiming }> {
   const scanStart = performance.now();
 
-  mediaItems = dropDuplicateDedupKeys(mediaItems);
+  const dedupedItems = dropDuplicateDedupKeys(mediaItems);
 
   // Filter to items with thumbnails (photos only, skip videos)
   // Include items with thumbnails. Video posters work too — two copies of the
   // same clip have identical poster frames, which produce near-identical
   // embeddings.
-  const candidates = mediaItems.filter((item) => item.thumb);
+  const candidates = dedupedItems.filter((item) => item.thumb);
   console.log(
     `[GPD] detectDuplicates: ${mediaItems.length} items → ${candidates.length} candidates`,
   );
@@ -491,12 +491,12 @@ export async function smartDetectDuplicates(
 ): Promise<DuplicateGroup[]> {
   const scanStart = performance.now();
 
-  mediaItems = dropDuplicateDedupKeys(mediaItems);
+  const dedupedItems = dropDuplicateDedupKeys(mediaItems);
 
   // Include items with thumbnails. Video posters work too — two copies of the
   // same clip have identical poster frames, which produce near-identical
   // embeddings.
-  const candidates = mediaItems.filter((item) => item.thumb);
+  const candidates = dedupedItems.filter((item) => item.thumb);
 
   // Step 1: Bucket by timestamp — no I/O, instant
   const buckets = groupByTimestamp(candidates, windowMs);

--- a/tests/lib/duplicate-detector.test.ts
+++ b/tests/lib/duplicate-detector.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { communityDetection, matMul, topK, groupByTimestamp, withinGroupDuplicates, selectDefaultKeep, fullDetectDuplicates } from "../../lib/duplicate-detector"
+import { communityDetection, matMul, topK, groupByTimestamp, withinGroupDuplicates, selectDefaultKeep, fullDetectDuplicates, dropDuplicateDedupKeys } from "../../lib/duplicate-detector"
 import type { GpdMediaItem } from "../../lib/types"
 
 // ============================================================
@@ -534,4 +534,41 @@ describe("selectDefaultKeep", () => {
     const result = selectDefaultKeep([a, b])
     expect(["a", "b"]).toContain(result)
   })
+})
+
+// ============================================================
+// dropDuplicateDedupKeys
+// ============================================================
+
+describe("dropDuplicateDedupKeys", () => {
+  it("keeps items with unique dedupKeys", () => {
+    const a = makeItem("media1", 1000)
+    a.dedupKey = "dedup1"
+    const b = makeItem("media2", 1000)
+    b.dedupKey = "dedup2"
+
+    const result = dropDuplicateDedupKeys([a, b])
+    expect(result).toHaveLength(2)
+    expect(result).toContain(a)
+    expect(result).toContain(b)
+  })
+
+  it("keeps only the first item with a duplicated dedupKey", () => {
+    const a = makeItem("media1", 1000)
+    a.dedupKey = "shared-dedup"
+    const b = makeItem("media2", 1000)
+    b.dedupKey = "shared-dedup"
+    const c = makeItem("media3", 1000)
+    c.dedupKey = "other-dedup"
+
+    const result = dropDuplicateDedupKeys([a, b, c])
+    expect(result).toHaveLength(2)
+    expect(result[0]).toBe(a)
+    expect(result[1]).toBe(c)
+  })
+
+  it("handles empty arrays", () => {
+    expect(dropDuplicateDedupKeys([])).toEqual([])
+  })
+
 })

--- a/tests/lib/duplicate-detector.test.ts
+++ b/tests/lib/duplicate-detector.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { communityDetection, matMul, topK, groupByTimestamp, withinGroupDuplicates, selectDefaultKeep, fullDetectDuplicates, dropDuplicateDedupKeys } from "../../lib/duplicate-detector"
+import { communityDetection, matMul, topK, groupByTimestamp, withinGroupDuplicates, selectDefaultKeep, fullDetectDuplicates, dedupeByDedupKey } from "../../lib/duplicate-detector"
 import type { GpdMediaItem } from "../../lib/types"
 
 // ============================================================
@@ -537,17 +537,17 @@ describe("selectDefaultKeep", () => {
 })
 
 // ============================================================
-// dropDuplicateDedupKeys
+// dedupeByDedupKey
 // ============================================================
 
-describe("dropDuplicateDedupKeys", () => {
+describe("dedupeByDedupKey", () => {
   it("keeps items with unique dedupKeys", () => {
     const a = makeItem("media1", 1000)
     a.dedupKey = "dedup1"
     const b = makeItem("media2", 1000)
     b.dedupKey = "dedup2"
 
-    const result = dropDuplicateDedupKeys([a, b])
+    const result = dedupeByDedupKey([a, b])
     expect(result).toHaveLength(2)
     expect(result).toContain(a)
     expect(result).toContain(b)
@@ -561,14 +561,13 @@ describe("dropDuplicateDedupKeys", () => {
     const c = makeItem("media3", 1000)
     c.dedupKey = "other-dedup"
 
-    const result = dropDuplicateDedupKeys([a, b, c])
+    const result = dedupeByDedupKey([a, b, c])
     expect(result).toHaveLength(2)
     expect(result[0]).toBe(a)
     expect(result[1]).toBe(c)
   })
 
   it("handles empty arrays", () => {
-    expect(dropDuplicateDedupKeys([])).toEqual([])
+    expect(dedupeByDedupKey([])).toEqual([])
   })
-
 })


### PR DESCRIPTION
There can be photos with different mediaKeys but same dedupKey, likely caused by saving shared albums.

We should not solve for them, since
- Google Photos natively collapses them into one in timeline/albums
- API doesn't allow to trash one of them without trashing others (it operates on dedupKey)

So pass to dedup step only the first item we see for each dedupKey.

This change reduces number of 100%/1sec duplicates in my library from 2000 to 3

Example of duplicates in question - diff of `getItemInfoExt`
<img width="1349" height="1225" alt="image" src="https://github.com/user-attachments/assets/5ac82cf3-a9a4-41a2-8a3d-df0afd232b98" />
