### PR TITLE
Make fullscreen view larger and have better quality photos

### DIFF
--- a/components/DuplicateGroups.tsx
+++ b/components/DuplicateGroups.tsx
@@ -349,6 +349,14 @@ export function DuplicateGroups({
       .filter((item): item is GpdMediaItem => !!item)
   }, [viewerState, mediaItems])
 
+  const nextGroupItems = useMemo(() => {
+    if (!viewerState || currentGroupIndex === -1 || currentGroupIndex >= groups.length - 1) return []
+    const nextGroup = groups[currentGroupIndex + 1]
+    return nextGroup.mediaKeys
+      .map((k) => mediaItems[k])
+      .filter((item): item is GpdMediaItem => !!item)
+  }, [viewerState, currentGroupIndex, groups, mediaItems])
+
   if (groups.length === 0) {
     const totalItems = Object.keys(mediaItems).length
     return (
@@ -391,6 +399,7 @@ export function DuplicateGroups({
         <PhotoViewerModal
           open={true}
           items={viewerItems}
+          nextGroupItems={nextGroupItems}
           initialIndex={viewerState.index}
           keptSet={keptByGroupId.get(viewerState.group.id)!}
           isGroupSelected={selectedGroupIds.has(viewerState.group.id)}

--- a/components/DuplicateGroups.tsx
+++ b/components/DuplicateGroups.tsx
@@ -13,6 +13,7 @@ import Typography from "@mui/material/Typography"
 import OpenInFullIcon from "@mui/icons-material/OpenInFull"
 import { useBlobUrl } from "./useBlobUrl"
 import { PhotoViewerModal } from "./PhotoViewerModal"
+import { buildThumbUrl } from "../lib/photo-url"
 import type { GpdMediaItem, DuplicateGroup } from "../lib/types"
 
 const PAGE_SIZE = 30
@@ -180,7 +181,7 @@ const DuplicateGroupRow = memo(function DuplicateGroupRow({
                 }]}>
                 <CardActionArea onClick={() => onToggleKept(group, key)}>
                   <ThumbnailImage
-                    src={item.thumb + "=h200"}
+                    src={buildThumbUrl(item.thumb, { height: 200 })}
                     alt={item.fileName || item.mediaKey}
                   />
                   <CardContent sx={sxCardContent}>

--- a/components/PhotoViewerModal.tsx
+++ b/components/PhotoViewerModal.tsx
@@ -17,6 +17,15 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew"
 import type { GpdMediaItem } from "../lib/types"
 
 /**
+ * Computes the optimal Google Photos URL for full-screen viewing based on current window size.
+ */
+function getFullResThumbUrl(thumb: string): string {
+  const width = Math.round(window.innerWidth * (window.devicePixelRatio || 1))
+  const height = Math.round(window.innerHeight * (window.devicePixelRatio || 1))
+  return `${thumb}=w${width}-h${height}`
+}
+
+/**
  * Preloads full-res blob URLs for all items in the group as soon as the modal
  * opens. Returns a stable map of mediaKey → blobUrl so navigating between
  * images is instant (no per-image fetch on demand).
@@ -42,9 +51,7 @@ function useGroupBlobUrls(items: GpdMediaItem[]): Record<string, string | undefi
 
       // Request thumnails of same size as window
       // Use window.devicePixelRatio to handle high-DPI displays
-      const width = Math.round(window.innerWidth * (window.devicePixelRatio || 1))
-      const height = Math.round(window.innerHeight * (window.devicePixelRatio || 1))
-      const fetchUrl = `${item.thumb}=w${width}-h${height}`
+      const fetchUrl = getFullResThumbUrl(item.thumb)
       fetch(fetchUrl, { credentials: "include", signal: controller.signal })
         .then((r) => (r.ok ? r.blob() : null))
         .then((blob) => {
@@ -104,9 +111,30 @@ function FullResImage({ item, blobUrl }: FullResImageProps) {
   )
 }
 
+function usePrefetchNextGroup(nextItems: GpdMediaItem[]) {
+  useEffect(() => {
+    if (nextItems.length === 0) return
+
+    const controllers: AbortController[] = []
+
+    nextItems.forEach((item) => {
+      const controller = new AbortController()
+      controllers.push(controller)
+      const fetchUrl = getFullResThumbUrl(item.thumb)
+      // Fire and forget to prime the browser HTTP cache
+      fetch(fetchUrl, { credentials: "include", signal: controller.signal }).catch(() => {})
+    })
+
+    return () => {
+      controllers.forEach((c) => c.abort())
+    }
+  }, [nextItems])
+}
+
 export interface PhotoViewerModalProps {
   open: boolean
   items: GpdMediaItem[]
+  nextGroupItems?: GpdMediaItem[]
   initialIndex: number
   keptSet: Set<string>
   isGroupSelected: boolean
@@ -129,6 +157,7 @@ const slideInFromLeft = keyframes`
 export function PhotoViewerModal({
   open,
   items,
+  nextGroupItems = [],
   initialIndex,
   keptSet,
   isGroupSelected,
@@ -144,6 +173,9 @@ export function PhotoViewerModal({
 
   // Preload all images in the group up front
   const blobUrls = useGroupBlobUrls(items)
+
+  // Prefetch the next group into browser cache so it's instant if the user navigates
+  usePrefetchNextGroup(nextGroupItems)
 
   // Reset index when the modal opens, the initial photo changes, or the items change
   useEffect(() => {

--- a/components/PhotoViewerModal.tsx
+++ b/components/PhotoViewerModal.tsx
@@ -40,7 +40,12 @@ function useGroupBlobUrls(items: GpdMediaItem[]): Record<string, string | undefi
       const controller = new AbortController()
       controllers.push(controller)
 
-      fetch(item.thumb, { credentials: "include", signal: controller.signal })
+      // Request thumnails of same size as window
+      // Use window.devicePixelRatio to handle high-DPI displays
+      const width = Math.round(window.innerWidth * (window.devicePixelRatio || 1))
+      const height = Math.round(window.innerHeight * (window.devicePixelRatio || 1))
+      const fetchUrl = `${item.thumb}=w${width}-h${height}`
+      fetch(fetchUrl, { credentials: "include", signal: controller.signal })
         .then((r) => (r.ok ? r.blob() : null))
         .then((blob) => {
           if (blob && !cancelled) {
@@ -228,8 +233,7 @@ export function PhotoViewerModal({
     <Dialog
       open={open}
       onClose={onClose}
-      fullWidth
-      maxWidth="lg"
+      fullScreen
       aria-label="Photo viewer"
       PaperProps={{
         sx: {
@@ -237,6 +241,8 @@ export function PhotoViewerModal({
           color: "white",
           position: "relative",
           overflow: "hidden",
+          display: "flex",
+          flexDirection: "column",
         },
       }}>
       {/* Header bar: filename left, counter center, close right */}
@@ -292,7 +298,7 @@ export function PhotoViewerModal({
           justifyContent: "center",
           position: "relative",
           bgcolor: "#111",
-          height: "70vh",
+          flex: 1,
           overflow: "hidden",
         }}>
         {/* Previous */}

--- a/components/PhotoViewerModal.tsx
+++ b/components/PhotoViewerModal.tsx
@@ -18,9 +18,11 @@ import { buildThumbUrl } from "../lib/photo-url"
 import type { GpdMediaItem } from "../lib/types"
 
 /**
- * Computes the optimal Google Photos URL for full-screen viewing based on current window size.
+ * Sizes a thumbnail URL to the current viewport (not necessarily the source
+ * photo's full resolution — a genuinely higher-res photo is still downscaled
+ * to fit the window).
  */
-function getFullResThumbUrl(thumb: string): string {
+function getViewportSizedThumbUrl(thumb: string): string {
   const width = Math.round(window.innerWidth * (window.devicePixelRatio || 1))
   const height = Math.round(window.innerHeight * (window.devicePixelRatio || 1))
   return buildThumbUrl(thumb, { width, height })
@@ -52,7 +54,7 @@ function useGroupBlobUrls(items: GpdMediaItem[]): Record<string, string | undefi
 
       // Request thumnails of same size as window
       // Use window.devicePixelRatio to handle high-DPI displays
-      const fetchUrl = getFullResThumbUrl(item.thumb)
+      const fetchUrl = getViewportSizedThumbUrl(item.thumb)
       fetch(fetchUrl, { credentials: "include", signal: controller.signal })
         .then((r) => (r.ok ? r.blob() : null))
         .then((blob) => {
@@ -121,7 +123,7 @@ function usePrefetchNextGroup(nextItems: GpdMediaItem[]) {
     nextItems.forEach((item) => {
       const controller = new AbortController()
       controllers.push(controller)
-      const fetchUrl = getFullResThumbUrl(item.thumb)
+      const fetchUrl = getViewportSizedThumbUrl(item.thumb)
       // Fire and forget to prime the browser HTTP cache
       fetch(fetchUrl, { credentials: "include", signal: controller.signal }).catch(() => {})
     })

--- a/components/PhotoViewerModal.tsx
+++ b/components/PhotoViewerModal.tsx
@@ -14,6 +14,7 @@ import ChevronRightIcon from "@mui/icons-material/ChevronRight"
 import CloseIcon from "@mui/icons-material/Close"
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline"
 import OpenInNewIcon from "@mui/icons-material/OpenInNew"
+import { buildThumbUrl } from "../lib/photo-url"
 import type { GpdMediaItem } from "../lib/types"
 
 /**
@@ -22,7 +23,7 @@ import type { GpdMediaItem } from "../lib/types"
 function getFullResThumbUrl(thumb: string): string {
   const width = Math.round(window.innerWidth * (window.devicePixelRatio || 1))
   const height = Math.round(window.innerHeight * (window.devicePixelRatio || 1))
-  return `${thumb}=w${width}-h${height}`
+  return buildThumbUrl(thumb, { width, height })
 }
 
 /**

--- a/lib/duplicate-detector.ts
+++ b/lib/duplicate-detector.ts
@@ -7,6 +7,7 @@
 // 3. Group duplicates using fast community detection (cosine similarity)
 
 import type { GpdMediaItem, DuplicateGroup } from "./types";
+import { buildThumbUrl } from "./photo-url";
 import { StabilityTracker } from "./scan-log";
 import type { ScanLogger } from "./scan-log";
 
@@ -639,7 +640,7 @@ async function fetchThumbnails(
       if (!entry) break;
 
       try {
-        const url = entry.item.thumb + `=h${THUMB_HEIGHT}`;
+        const url = buildThumbUrl(entry.item.thumb, { height: THUMB_HEIGHT });
         const response = await fetch(url, {
           credentials: "include",
           signal: (AbortSignal as typeof AbortSignal & { any(signals: AbortSignal[]): AbortSignal }).any([

--- a/lib/photo-url.ts
+++ b/lib/photo-url.ts
@@ -1,0 +1,14 @@
+// Google Photos media URLs (GpdMediaItem.thumb) are "bare" — no size suffix —
+// and accept an appended directive to request a specific rendition:
+// `=h{height}` scales to a height (preserving aspect ratio); `=w{width}-h{height}`
+// scales/crops to fit both dimensions. This is the one place that builds those
+// URLs; every call site should go through here rather than concatenating its
+// own suffix.
+
+export function buildThumbUrl(
+  thumb: string,
+  size: { height: number; width?: number }
+): string {
+  const { width, height } = size;
+  return width ? `${thumb}=w${width}-h${height}` : `${thumb}=h${height}`;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -155,7 +155,7 @@ export type AppMessage =
 export interface GpdMediaItem {
   mediaKey: string;
   dedupKey: string;
-  thumb: string; // thumbnail URL (append =w200-h200 for thumbnails; use bare for full-res)
+  thumb: string; // bare thumbnail URL; use buildThumbUrl() in lib/photo-url.ts to request a sized rendition
   productUrl?: string; // link to item in Google Photos web app
   timestamp: number; // taken date
   creationTimestamp: number; // upload date

--- a/test-assign.js
+++ b/test-assign.js
@@ -1,0 +1,4 @@
+const { Window } = require('happy-dom');
+const window = new Window();
+Object.assign(window, { innerWidth: 1000, innerHeight: 800, devicePixelRatio: 2 });
+console.log(window.innerWidth, window.innerHeight, window.devicePixelRatio);

--- a/test-assign.js
+++ b/test-assign.js
@@ -1,4 +1,0 @@
-const { Window } = require('happy-dom');
-const window = new Window();
-Object.assign(window, { innerWidth: 1000, innerHeight: 800, devicePixelRatio: 2 });
-console.log(window.innerWidth, window.innerHeight, window.devicePixelRatio);

--- a/tests/components/photo-viewer-modal.test.tsx
+++ b/tests/components/photo-viewer-modal.test.tsx
@@ -405,3 +405,35 @@ describe("PhotoViewerModal — Shift keyboard group shortcuts", () => {
     expect(onNextGroup).toHaveBeenCalledOnce()
   })
 })
+
+// ============================================================
+// Fetching and Prefetching
+// ============================================================
+
+describe("PhotoViewerModal — fetching and prefetching", () => {
+  it("fetches images with dimensions based on window size and devicePixelRatio", () => {
+    Object.assign(window, { innerWidth: 1000, innerHeight: 800, devicePixelRatio: 2 })
+
+    const fetchSpy = vi.spyOn(global, "fetch")
+    wrap(<PhotoViewerModal {...defaultProps} />)
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("https://example.com/img1=w2000-h1600"),
+      expect.any(Object)
+    )
+  })
+
+  it("prefetches nextGroupItems when provided", () => {
+    Object.assign(window, { innerWidth: 1000, innerHeight: 800, devicePixelRatio: 2 })
+
+    const fetchSpy = vi.spyOn(global, "fetch")
+    const nextGroupItems = [makeItem("img4")]
+
+    wrap(<PhotoViewerModal {...defaultProps} nextGroupItems={nextGroupItems} />)
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://example.com/img4=w2000-h1600",
+      expect.any(Object)
+    )
+  })
+})


### PR DESCRIPTION
I was hard to spot differences in the fullscreen mode due to size of photos and their default resolution (it was 512x384)

How UI looks now:
<img width="1748" height="1312" alt="horizontal" src="https://github.com/user-attachments/assets/05b74135-c9ce-44b7-8588-abbd24a06315" />
<img width="1748" height="1312" alt="vertical" src="https://github.com/user-attachments/assets/5c776503-0582-4365-94af-ef958cdbd191" />

As result, loading of each duplicate group takes longer, so we are now preloading next group in the background:
<img width="778" height="348" alt="image" src="https://github.com/user-attachments/assets/cf813108-f0dd-445d-a6db-e81c376f8d1b" />
