### PR TITLE
feat: preview photo with Spacebar while hovering

### DIFF
--- a/components/DuplicateGroups.tsx
+++ b/components/DuplicateGroups.tsx
@@ -126,6 +126,8 @@ interface DuplicateGroupRowProps {
   onToggleGroup: (groupId: string) => void
   onToggleKept: (group: DuplicateGroup, mediaKey: string) => void
   onOpenViewer: (group: DuplicateGroup, index: number) => void
+  onMouseEnterPhoto: (group: DuplicateGroup, index: number) => void
+  onMouseLeavePhoto: () => void
 }
 
 const DuplicateGroupRow = memo(function DuplicateGroupRow({
@@ -136,6 +138,8 @@ const DuplicateGroupRow = memo(function DuplicateGroupRow({
   onToggleGroup,
   onToggleKept,
   onOpenViewer,
+  onMouseEnterPhoto,
+  onMouseLeavePhoto,
 }: DuplicateGroupRowProps) {
   return (
     <Paper
@@ -171,7 +175,11 @@ const DuplicateGroupRow = memo(function DuplicateGroupRow({
           const isKept = keptSet.has(key)
 
           return (
-            <Box key={key} sx={sxItemWrapper}>
+            <Box
+              key={key}
+              sx={sxItemWrapper}
+              onMouseEnter={() => onMouseEnterPhoto(group, itemIndex)}
+              onMouseLeave={() => onMouseLeavePhoto()}>
               <Card
                 variant="outlined"
                 sx={[sxCardBase, {
@@ -299,6 +307,11 @@ export function DuplicateGroups({
     group: DuplicateGroup
     index: number
   } | null>(null)
+  const hoveredPhotoRef = useRef<{
+    group: DuplicateGroup
+    index: number
+  } | null>(null)
+
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
   const sentinelRef = useRef<HTMLDivElement>(null)
 
@@ -323,6 +336,26 @@ export function DuplicateGroups({
   const onOpenViewer = useCallback((group: DuplicateGroup, index: number) => {
     setViewerState({ group, index })
   }, [])
+
+  const onMouseEnterPhoto = useCallback((group: DuplicateGroup, index: number) => {
+    hoveredPhotoRef.current = { group, index }
+  }, [])
+
+  const onMouseLeavePhoto = useCallback(() => {
+    hoveredPhotoRef.current = null
+  }, [])
+
+  // Spacebar key opens preview for the photo under the cursor
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === " " && hoveredPhotoRef.current && !viewerState) {
+        e.preventDefault()
+        onOpenViewer(hoveredPhotoRef.current.group, hoveredPhotoRef.current.index)
+      }
+    }
+    window.addEventListener("keydown", handler)
+    return () => window.removeEventListener("keydown", handler)
+  }, [viewerState, onOpenViewer])
 
   const currentGroupIndex = useMemo(() => {
     return viewerState
@@ -380,6 +413,8 @@ export function DuplicateGroups({
           onToggleGroup={onToggleGroup}
           onToggleKept={onToggleKept}
           onOpenViewer={onOpenViewer}
+          onMouseEnterPhoto={onMouseEnterPhoto}
+          onMouseLeavePhoto={onMouseLeavePhoto}
         />
       ))}
 

--- a/tests/components/duplicate-groups.test.tsx
+++ b/tests/components/duplicate-groups.test.tsx
@@ -8,7 +8,7 @@
  * - Zoom button does not trigger onToggleKept (stopPropagation)
  */
 import { describe, it, expect, vi } from "vitest"
-import { render, screen, fireEvent } from "@testing-library/react"
+import { render, screen, fireEvent, act } from "@testing-library/react"
 import { ThemeProvider, createTheme } from "@mui/material/styles"
 import { DuplicateGroups } from "../../components/DuplicateGroups"
 import type { GpdMediaItem, DuplicateGroup } from "../../lib/types"
@@ -244,5 +244,40 @@ describe("DuplicateGroups — empty state", () => {
   it("shows no duplicates message when groups is empty", () => {
     wrap(<DuplicateGroups {...defaultProps} groups={[]} />)
     expect(screen.getByText(/no duplicates found/i)).toBeInTheDocument()
+  })
+})
+
+// ============================================================
+// Spacebar preview
+// ============================================================
+
+describe("DuplicateGroups — Spacebar preview", () => {
+  it("opens the viewer modal when 'Space' is pressed while hovering a photo", () => {
+    wrap(<DuplicateGroups {...defaultProps} />)
+    expect(screen.queryByTestId("viewer-modal")).not.toBeInTheDocument()
+
+    const img1Card = screen.getByTitle("img1.jpg").closest(".MuiBox-root")
+    expect(img1Card).toBeTruthy()
+
+    // Hover over the first photo
+    act(() => {
+      fireEvent.mouseOver(img1Card!)
+    })
+
+    // Press ' ' (Spacebar)
+    const spy = vi.spyOn(KeyboardEvent.prototype, "preventDefault")
+    act(() => {
+      fireEvent.keyDown(window, { key: " ", code: "Space" })
+    })
+
+    expect(screen.getByTestId("viewer-modal")).toBeInTheDocument()
+    expect(spy).toHaveBeenCalled()
+    spy.mockRestore()
+  })
+
+  it("does not open the viewer modal when 'Space' is pressed but no photo is hovered", () => {
+    wrap(<DuplicateGroups {...defaultProps} />)
+    fireEvent.keyDown(window, { key: " ", code: "Space" })
+    expect(screen.queryByTestId("viewer-modal")).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Implements spacebar preview while hovering over photos in DuplicateGroups. This follows common UI patterns for quick photo inspection.