### PR TITLE
feat: cycle Keep/Trash designation with ArrowUp and ArrowDown

### DIFF
--- a/components/DuplicateGroups.tsx
+++ b/components/DuplicateGroups.tsx
@@ -169,7 +169,19 @@ const DuplicateGroupRow = memo(function DuplicateGroupRow({
       </Box>
 
       {/* Thumbnails */}
-      <Box sx={sxThumbnailsWrapper}>
+      <Box
+        sx={sxThumbnailsWrapper}
+        onMouseOver={(e) => {
+          const target = (e.target as HTMLElement).closest("[data-item-index]")
+          if (target) {
+            const index = parseInt(target.getAttribute("data-item-index") || "0", 10)
+            onMouseEnterPhoto(group, index)
+          }
+        }}
+        onMouseOut={(e) => {
+          const target = (e.target as HTMLElement).closest("[data-item-index]")
+          if (target) onMouseLeavePhoto()
+        }}>
         {group.mediaKeys.map((key, itemIndex) => {
           const item = mediaItems[key]
           if (!item) return null
@@ -179,8 +191,7 @@ const DuplicateGroupRow = memo(function DuplicateGroupRow({
             <Box
               key={key}
               sx={sxItemWrapper}
-              onMouseEnter={() => onMouseEnterPhoto(group, itemIndex)}
-              onMouseLeave={() => onMouseLeavePhoto()}>
+              data-item-index={itemIndex}>
               <Card
                 variant="outlined"
                 sx={[sxCardBase, {

--- a/components/PhotoViewerModal.tsx
+++ b/components/PhotoViewerModal.tsx
@@ -221,16 +221,10 @@ export function PhotoViewerModal({
           navigate(Math.max(0, index - 1))
         } else if (e.key === "ArrowRight") {
           navigate(Math.min(items.length - 1, index + 1))
-        } else if (e.key === "ArrowUp") {
+        } else if (e.key === "ArrowUp" || e.key === "ArrowDown") {
           e.preventDefault()
           const item = items[Math.min(index, items.length - 1)]
-          if (item && !keptSet.has(item.mediaKey)) {
-            onToggleKept?.(item.mediaKey)
-          }
-        } else if (e.key === "ArrowDown") {
-          e.preventDefault()
-          const item = items[Math.min(index, items.length - 1)]
-          if (item && keptSet.has(item.mediaKey)) {
+          if (item) {
             onToggleKept?.(item.mediaKey)
           }
         }
@@ -491,12 +485,8 @@ export function PhotoViewerModal({
               <Typography variant="body2" sx={{ fontFamily: "monospace" }}>← / →</Typography>
             </Box>
             <Box sx={{ display: "flex", justifyContent: "space-between" }}>
-              <Typography variant="body2" sx={{ color: "rgba(255,255,255,0.7)" }}>Keep photo</Typography>
-              <Typography variant="body2" sx={{ fontFamily: "monospace" }}>↑</Typography>
-            </Box>
-            <Box sx={{ display: "flex", justifyContent: "space-between" }}>
-              <Typography variant="body2" sx={{ color: "rgba(255,255,255,0.7)" }}>Trash photo</Typography>
-              <Typography variant="body2" sx={{ fontFamily: "monospace" }}>↓</Typography>
+              <Typography variant="body2" sx={{ color: "rgba(255,255,255,0.7)" }}>Toggle Keep / Trash</Typography>
+              <Typography variant="body2" sx={{ fontFamily: "monospace" }}>↑ / ↓</Typography>
             </Box>
             <Box sx={{ display: "flex", justifyContent: "space-between" }}>
               <Typography variant="body2" sx={{ color: "rgba(255,255,255,0.7)" }}>Previous / Next group</Typography>

--- a/tests/components/photo-viewer-modal.test.tsx
+++ b/tests/components/photo-viewer-modal.test.tsx
@@ -265,7 +265,7 @@ describe("PhotoViewerModal — close", () => {
 // ============================================================
 
 describe("PhotoViewerModal — keyboard keep toggling", () => {
-  it("calls onToggleKept when pressing ArrowUp on a non-kept image", () => {
+  it("calls onToggleKept when pressing ArrowUp on a non-kept image (toggle on)", () => {
     const onToggleKept = vi.fn()
     wrap(
       <PhotoViewerModal
@@ -278,7 +278,7 @@ describe("PhotoViewerModal — keyboard keep toggling", () => {
     expect(onToggleKept).toHaveBeenCalledWith("img2")
   })
 
-  it("does NOT call onToggleKept when pressing ArrowUp on an already kept image", () => {
+  it("calls onToggleKept when pressing ArrowUp on an already kept image (toggle off)", () => {
     const onToggleKept = vi.fn()
     wrap(
       <PhotoViewerModal
@@ -288,10 +288,10 @@ describe("PhotoViewerModal — keyboard keep toggling", () => {
       />
     )
     fireEvent.keyDown(window, { key: "ArrowUp" })
-    expect(onToggleKept).not.toHaveBeenCalled()
+    expect(onToggleKept).toHaveBeenCalledWith("img1")
   })
 
-  it("calls onToggleKept when pressing ArrowDown on a kept image", () => {
+  it("calls onToggleKept when pressing ArrowDown on a kept image (toggle off)", () => {
     const onToggleKept = vi.fn()
     wrap(
       <PhotoViewerModal
@@ -304,7 +304,7 @@ describe("PhotoViewerModal — keyboard keep toggling", () => {
     expect(onToggleKept).toHaveBeenCalledWith("img1")
   })
 
-  it("does NOT call onToggleKept when pressing ArrowDown on a non-kept image", () => {
+  it("calls onToggleKept when pressing ArrowDown on a non-kept image (toggle on)", () => {
     const onToggleKept = vi.fn()
     wrap(
       <PhotoViewerModal
@@ -314,7 +314,7 @@ describe("PhotoViewerModal — keyboard keep toggling", () => {
       />
     )
     fireEvent.keyDown(window, { key: "ArrowDown" })
-    expect(onToggleKept).not.toHaveBeenCalled()
+    expect(onToggleKept).toHaveBeenCalledWith("img2")
   })
 })
 


### PR DESCRIPTION
Adds ArrowUp and ArrowDown as toggles for the Keep/Trash designation in the photo viewer, so a photo's status can be changed without leaving preview mode. Updates the shortcuts help dialog and tests to match.