### PR TITLE
perf: cap oversized timestamp buckets in smart detection

### DIFF
--- a/components/DuplicateGroups.tsx
+++ b/components/DuplicateGroups.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import Alert from "@mui/material/Alert"
 import Box from "@mui/material/Box"
 import Card from "@mui/material/Card"
 import CardActionArea from "@mui/material/CardActionArea"
@@ -278,6 +279,11 @@ interface DuplicateGroupsProps {
   onToggleGroup: (groupId: string) => void
   keptByGroupId: Map<string, Set<string>>
   onToggleKept: (group: DuplicateGroup, mediaKey: string) => void
+  /**
+   * Timestamp buckets split during the scan to keep pairwise comparison
+   * bounded. Above zero, results are incomplete and we say so.
+   */
+  bucketsSplit?: number
 }
 
 export function DuplicateGroups({
@@ -287,6 +293,7 @@ export function DuplicateGroups({
   onToggleGroup,
   keptByGroupId,
   onToggleKept,
+  bucketsSplit = 0,
 }: DuplicateGroupsProps) {
   // Measure time from first non-empty groups render to commit
   const renderLoggedRef = useRef(false)
@@ -411,6 +418,14 @@ export function DuplicateGroups({
       <Typography variant="h6" fontWeight={600} sx={{ px: 0, py: 2 }}>
         {groups.length} Duplicate Group{groups.length !== 1 ? "s" : ""} Found
       </Typography>
+
+      {bucketsSplit > 0 && (
+        <Alert severity="info" data-testid="split-buckets-notice" sx={{ mb: 2 }}>
+          {bucketsSplit} large time {bucketsSplit === 1 ? "group was" : "groups were"} split
+          to keep the scan fast — duplicates spanning a split may be missed. Narrow the
+          time window to compare fewer photos at once.
+        </Alert>
+      )}
 
       {groups.slice(0, visibleCount).map((group) => (
         <DuplicateGroupRow

--- a/lib/app-reducer.ts
+++ b/lib/app-reducer.ts
@@ -33,6 +33,10 @@ export type AppState =
       mediaItems: Record<string, GpdMediaItem>
       groups: DuplicateGroup[]
       totalItems: number
+      // How many timestamp buckets were split to bound comparison cost.
+      // > 0 means some duplicates spanning a split may not have been found.
+      // Optional: results persisted before this existed won't carry it.
+      bucketsSplit?: number
       accountEmail?: string
     }
   | {
@@ -42,6 +46,7 @@ export type AppState =
       totalItems: number
       totalToTrash: number
       trashedSoFar: number
+      bucketsSplit?: number
       accountEmail?: string
     }
 
@@ -54,6 +59,7 @@ export type AppAction =
       type: "SCAN_COMPLETE"
       mediaItems: Record<string, GpdMediaItem>
       groups: DuplicateGroup[]
+      bucketsSplit?: number
     }
   | { type: "SCAN_ERROR"; error: string }
   | { type: "SCAN_CANCELLED" }
@@ -72,6 +78,7 @@ export type AppAction =
       mediaItems: Record<string, GpdMediaItem>
       groups: DuplicateGroup[]
       totalItems: number
+      bucketsSplit?: number
       accountEmail?: string
     }
   | {
@@ -155,6 +162,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         mediaItems: action.mediaItems,
         groups: action.groups,
         totalItems: Object.keys(action.mediaItems).length,
+        bucketsSplit: action.bucketsSplit ?? 0,
         accountEmail: "accountEmail" in state ? state.accountEmail : undefined,
       }
 
@@ -173,6 +181,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         totalItems: action.totalItems,
         totalToTrash: action.totalToTrash,
         trashedSoFar: 0,
+        bucketsSplit: "bucketsSplit" in state ? state.bucketsSplit : 0,
         accountEmail: "accountEmail" in state ? state.accountEmail : undefined,
       }
 
@@ -200,6 +209,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         mediaItems: newMediaItems,
         groups: newGroups,
         totalItems: state.totalItems,
+        bucketsSplit: state.bucketsSplit,
         accountEmail: state.accountEmail,
       }
     }
@@ -213,6 +223,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         mediaItems: action.mediaItems,
         groups: action.groups,
         totalItems: action.totalItems,
+        bucketsSplit: action.bucketsSplit ?? 0,
         accountEmail: action.accountEmail,
       }
 
@@ -222,6 +233,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         mediaItems: action.mediaItems,
         groups: action.groups,
         totalItems: action.totalItems,
+        bucketsSplit: "bucketsSplit" in state ? state.bucketsSplit : 0,
         accountEmail: "accountEmail" in state ? state.accountEmail : undefined,
       }
 

--- a/lib/duplicate-detector.ts
+++ b/lib/duplicate-detector.ts
@@ -354,6 +354,12 @@ export function groupByTimestamp(
 ): GpdMediaItem[][] {
   const buckets = new Map<number, GpdMediaItem[]>();
   for (const item of items) {
+    // Guard degenerate timestamps. `undefined` floors to NaN and Map treats
+    // every NaN as the same key; `null` floors to 0 and silently joins the
+    // epoch bucket. Either way every affected item collapses into one bucket,
+    // whose pairwise comparison is quadratic in the size of that collapse.
+    // Such items can't be time-matched anyway, so drop them from bucketing.
+    if (!Number.isFinite(item.timestamp)) continue;
     const key =
       windowMs > 0
         ? Math.floor(item.timestamp / windowMs) * windowMs
@@ -362,6 +368,54 @@ export function groupByTimestamp(
     buckets.get(key)!.push(item);
   }
   return [...buckets.values()].filter((g) => g.length >= 2);
+}
+
+/**
+ * Largest timestamp bucket we will compare pairwise in one piece.
+ *
+ * Comparison cost is quadratic in bucket size, so a single dense bucket can
+ * dominate an entire scan: at the measured worker throughput a 5,000-item
+ * bucket takes roughly 20 seconds, while a 50,000-item one takes over half an
+ * hour. Wide time windows make this easy to hit — one busy hour or a bulk
+ * import can drop thousands of photos into the same bucket.
+ */
+export const MAX_BUCKET_SIZE = 5000;
+
+/**
+ * Split buckets larger than `cap` into smaller, time-contiguous chunks so no
+ * single pairwise comparison runs unbounded.
+ *
+ * Chunks are near-equal rather than cap-sized — splitting 5,001 items at a cap
+ * of 5,000 yields 2,501 + 2,500, not 5,000 + 1. Items are sorted by timestamp
+ * first so each chunk covers a contiguous slice of time, which is where real
+ * duplicates cluster.
+ *
+ * This trades recall for a bounded runtime: duplicates that straddle a chunk
+ * boundary are not detected. `bucketsSplit` counts how many source buckets
+ * were affected so the UI can say so.
+ */
+export function splitOversizedBuckets(
+  buckets: GpdMediaItem[][],
+  cap = MAX_BUCKET_SIZE,
+): { buckets: GpdMediaItem[][]; bucketsSplit: number } {
+  const out: GpdMediaItem[][] = [];
+  let bucketsSplit = 0;
+
+  for (const bucket of buckets) {
+    if (bucket.length <= cap) {
+      out.push(bucket);
+      continue;
+    }
+    bucketsSplit++;
+
+    const sorted = [...bucket].sort((a, b) => a.timestamp - b.timestamp);
+    const chunkCount = Math.ceil(sorted.length / cap);
+    const chunkSize = Math.ceil(sorted.length / chunkCount);
+    for (let i = 0; i < sorted.length; i += chunkSize)
+      out.push(sorted.slice(i, i + chunkSize));
+  }
+
+  return { buckets: out, bucketsSplit };
 }
 
 /**
@@ -489,7 +543,7 @@ export async function smartDetectDuplicates(
   onProgress?: ProgressCallback,
   signal?: AbortSignal,
   logger?: ScanLogger,
-): Promise<DuplicateGroup[]> {
+): Promise<{ groups: DuplicateGroup[]; bucketsSplit: number }> {
   const scanStart = performance.now();
 
   const dedupedItems = dedupeByDedupKey(mediaItems);
@@ -500,11 +554,16 @@ export async function smartDetectDuplicates(
   const candidates = dedupedItems.filter((item) => item.thumb);
 
   // Step 1: Bucket by timestamp — no I/O, instant
-  const buckets = groupByTimestamp(candidates, windowMs);
+  const rawBuckets = groupByTimestamp(candidates, windowMs);
+
+  // Step 1b: Cap bucket size. Pairwise cost is quadratic within a bucket, so
+  // one dense hour can otherwise stall the whole scan.
+  const { buckets, bucketsSplit } = splitOversizedBuckets(rawBuckets);
+  const largest = buckets.reduce((max, b) => Math.max(max, b.length), 0);
   console.log(
-    `[GPD] smartDetectDuplicates: ${mediaItems.length} items → ${candidates.length} candidates → ${buckets.length} timestamp buckets`,
+    `[GPD] smartDetectDuplicates: ${mediaItems.length} items → ${candidates.length} candidates → ${buckets.length} timestamp buckets (largest ${largest}${bucketsSplit > 0 ? `, ${bucketsSplit} split at cap ${MAX_BUCKET_SIZE}` : ""})`,
   );
-  if (buckets.length === 0) return [];
+  if (buckets.length === 0) return { groups: [], bucketsSplit };
 
   // Flatten to deduplicated subset
   const seen = new Set<string>();
@@ -570,7 +629,7 @@ export async function smartDetectDuplicates(
   );
   await logger?.phaseComplete("computeEmbeddingsMs", computeEmbeddingsMs);
 
-  if (embeddings.length < 2) return [];
+  if (embeddings.length < 2) return { groups: [], bucketsSplit };
 
   // Build bucket index arrays (indices into embeddings[])
   const mediaKeyToEmbIdx = new Map<string, number>();
@@ -585,7 +644,7 @@ export async function smartDetectDuplicates(
     )
     .filter((b) => b.length >= 2);
 
-  if (workerBuckets.length === 0) return [];
+  if (workerBuckets.length === 0) return { groups: [], bucketsSplit };
 
   // Offload pairwise comparison to worker
   trackedProgress({ phase: "detecting_duplicates", current: 0, total: 0 });
@@ -621,7 +680,10 @@ export async function smartDetectDuplicates(
     };
   });
 
-  return groups.sort((a, b) => b.mediaKeys.length - a.mediaKeys.length);
+  return {
+    groups: groups.sort((a, b) => b.mediaKeys.length - a.mediaKeys.length),
+    bucketsSplit,
+  };
 }
 
 // ============================================================

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -186,6 +186,10 @@ export interface StoredState {
     scanDate: number;
     totalItems: number;
     newestCreationTimestamp?: number; // for incremental fetch on next scan
+    // Timestamp buckets split to bound comparison cost; > 0 means the scan
+    // may have missed duplicates spanning a split. Absent on results saved
+    // before this was recorded.
+    bucketsSplit?: number;
     accountEmail?: string;
   };
   selections?: {

--- a/notes/2026-08-28-smart-detect-bucket-cap.md
+++ b/notes/2026-08-28-smart-detect-bucket-cap.md
@@ -1,0 +1,168 @@
+# Capping oversized timestamp buckets in smart detection
+
+*2026-08-28T22:16:06Z by Showboat 0.6.1*
+<!-- showboat-id: e20fb666-0668-4b2a-bac9-7d4371e3c0f3 -->
+
+## The problem
+
+Smart mode buckets photos by timestamp, then compares every pair *within* each
+bucket. That cost is quadratic in bucket size. With a wide time window (the 1h
+setting), one dense hour — a wedding, a burst-shoot, a bulk import — drops
+thousands of photos into a single bucket and the scan appears to hang.
+
+It is not a frozen UI: detection runs in a worker, and cancel works because
+`runSmartDetectionInWorker` calls `worker.terminate()` on abort. The user-visible
+failure is that progress was only posted every 100 buckets, so a single huge
+bucket showed no movement at all for tens of minutes.
+
+Measured worker throughput is 6.26e8 multiply-adds/sec at dim=1024, which puts a
+50,000-item bucket at ~34 minutes.
+
+## The change
+
+`splitOversizedBuckets` caps any bucket at `MAX_BUCKET_SIZE` (5,000), splitting
+oversized ones into near-equal, time-contiguous chunks. This trades recall for a
+bounded runtime — duplicates straddling a chunk boundary are missed — so the
+count of split buckets is surfaced in the results UI.
+
+`groupByTimestamp` also now drops items whose timestamp is not finite. Previously
+`undefined` produced a `NaN` key, and since `Map` treats every `NaN` as the same
+key, all such items collapsed into one bucket; `null` floored to 0 and silently
+joined the epoch bucket.
+
+## Diff under test
+
+```bash
+git diff --stat
+```
+
+```output
+ components/DuplicateGroups.tsx             |  15 ++++
+ lib/app-reducer.ts                         |  12 +++
+ lib/duplicate-detector.ts                  |  76 ++++++++++++++--
+ lib/types.ts                               |   4 +
+ package-lock.json                          |   2 +
+ tabs/app.tsx                               |  18 +++-
+ tests/components/duplicate-groups.test.tsx |  32 +++++++
+ tests/lib/app-reducer.test.ts              |  71 +++++++++++++++
+ tests/lib/duplicate-detector.test.ts       | 136 ++++++++++++++++++++++++++++-
+ workers/embedder.worker.ts                 |   7 +-
+ 10 files changed, 359 insertions(+), 14 deletions(-)
+```
+
+```bash
+sed -n '/^export const MAX_BUCKET_SIZE/,/^}/p' lib/duplicate-detector.ts
+```
+
+```output
+export const MAX_BUCKET_SIZE = 5000;
+
+/**
+ * Split buckets larger than `cap` into smaller, time-contiguous chunks so no
+ * single pairwise comparison runs unbounded.
+ *
+ * Chunks are near-equal rather than cap-sized — splitting 5,001 items at a cap
+ * of 5,000 yields 2,501 + 2,500, not 5,000 + 1. Items are sorted by timestamp
+ * first so each chunk covers a contiguous slice of time, which is where real
+ * duplicates cluster.
+ *
+ * This trades recall for a bounded runtime: duplicates that straddle a chunk
+ * boundary are not detected. `bucketsSplit` counts how many source buckets
+ * were affected so the UI can say so.
+ */
+export function splitOversizedBuckets(
+  buckets: GpdMediaItem[][],
+  cap = MAX_BUCKET_SIZE,
+): { buckets: GpdMediaItem[][]; bucketsSplit: number } {
+  const out: GpdMediaItem[][] = [];
+  let bucketsSplit = 0;
+
+  for (const bucket of buckets) {
+    if (bucket.length <= cap) {
+      out.push(bucket);
+      continue;
+    }
+    bucketsSplit++;
+
+    const sorted = [...bucket].sort((a, b) => a.timestamp - b.timestamp);
+    const chunkCount = Math.ceil(sorted.length / cap);
+    const chunkSize = Math.ceil(sorted.length / chunkCount);
+    for (let i = 0; i < sorted.length; i += chunkSize)
+      out.push(sorted.slice(i, i + chunkSize));
+  }
+
+  return { buckets: out, bucketsSplit };
+}
+```
+
+## Typecheck and full suite
+
+248 tests, up from 225 on the base commit — 23 new covering the split function,
+the non-finite timestamp guard, reducer plumbing, and the UI notice.
+
+```bash
+npx tsc --noEmit -p tsconfig.json && echo 'typecheck: clean' && npm test 2>&1 | tail -6
+```
+
+```output
+typecheck: clean
+
+ Test Files  13 passed (13)
+      Tests  248 passed (248)
+   Start at  15:17:04
+   Duration  1.36s (transform 734ms, setup 576ms, import 1.92s, tests 2.12s, environment 2.70s)
+
+```
+
+## Exercised against a synthetic 121k-item library
+
+Unit tests prove the contract; this runs the real `groupByTimestamp` and
+`splitOversizedBuckets` (bundled with esbuild) over a library shaped like a real
+one: 40,000 sparse photos plus three dense bursts of 8k / 20k / 50k that each
+land inside a single 1-hour bucket, plus 3,000 items with no timestamp.
+
+Times are derived from the measured worker rate of 6.26e8 multiply-adds/sec at
+dim=1024, not wall-clock — running the actual comparisons would take the 40
+minutes the fix exists to avoid. The harness is throwaway and lives outside the
+repo, so this block will not reproduce on a later `showboat verify`.
+
+```bash
+node /private/tmp/claude-501/-Users-yakovv-marina-work-deduper/41396d94-0894-44a5-90dd-b4886ea0e177/scratchpad/exercise/out.cjs
+```
+
+```output
+library: 121000 items (3,000 with undefined timestamps)
+
+BEFORE cap:
+  buckets: 3334, largest three: 50012, 20012, 8012
+  worst single bucket: 34.1 min
+  total pairwise time: 40.4 min
+
+AFTER cap (MAX_BUCKET_SIZE=5000):
+  buckets: 3349, largest three: 4547, 4547, 4547
+  bucketsSplit reported: 3
+  worst single bucket: 16.9 s
+  total pairwise time: 4.63 min
+
+items preserved:       118000 -> 118000  OK
+max bucket <= cap:     OK
+bad timestamps dropped: OK
+```
+
+## Result
+
+| | before | after |
+|---|---|---|
+| worst single bucket | 34.1 min | 16.9 s |
+| total pairwise time | 40.4 min | 4.63 min |
+| buckets split | — | 3 (surfaced in UI) |
+
+No items lost, no bucket above the cap, and the 3,000 timestamp-less items are
+excluded from bucketing instead of collapsing into one 3,000-item bucket.
+
+## Known limitation
+
+Duplicates that straddle a chunk boundary are not detected. That is the trade
+this change makes deliberately, and the results page now says so whenever
+`bucketsSplit > 0`. The full-mode `topK` problem (a separate O(n^2 log n) bug in
+`workerCommunityDetection`) is untouched here.

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -337,7 +337,9 @@ export default function App() {
           })
         }
 
-        const groups =
+        // Smart mode reports how many timestamp buckets it had to split to
+        // keep pairwise comparison bounded; full mode never splits.
+        const { groups, bucketsSplit } =
           settingsRef.current.scanMode === "smart"
             ? await smartDetectDuplicates(
                 items,
@@ -355,7 +357,7 @@ export default function App() {
                   signal,
                   logger
                 )
-                return result.groups
+                return { groups: result.groups, bucketsSplit: 0 }
               })()
 
         await logger.finalize("complete", { groupsFound: groups.length })
@@ -369,7 +371,8 @@ export default function App() {
         dispatch({
           type: "SCAN_COMPLETE",
           mediaItems: mediaItemMap,
-          groups
+          groups,
+          bucketsSplit
         })
         // Refresh account email after scan — the email in state may be stale
         // if the user switched accounts since the last health check.
@@ -421,6 +424,7 @@ export default function App() {
             mediaItems: result.scanResults.mediaItems,
             groups: result.scanResults.groups,
             totalItems: result.scanResults.totalItems,
+            bucketsSplit: result.scanResults.bucketsSplit,
             accountEmail: result.scanResults.accountEmail
           })
         }
@@ -483,6 +487,10 @@ export default function App() {
   )
   const totalItems = state.status === "results" ? state.totalItems : 0
   const accountEmailForStorage = state.status === "results" ? state.accountEmail : undefined
+  const bucketsSplit =
+    state.status === "results" || state.status === "trashing"
+      ? state.bucketsSplit
+      : 0
   useEffect(() => {
     if (!mediaItems) return
     if (groups.length > 0) {
@@ -497,6 +505,7 @@ export default function App() {
           scanDate: Date.now(),
           totalItems,
           newestCreationTimestamp,
+          bucketsSplit,
           accountEmail: accountEmailForStorage
         }
       })
@@ -504,7 +513,7 @@ export default function App() {
       // All duplicates removed — clear saved results so next open starts fresh
       chrome.storage.local.remove("scanResults")
     }
-  }, [groups, mediaItems, totalItems, accountEmailForStorage])
+  }, [groups, mediaItems, totalItems, bucketsSplit, accountEmailForStorage])
 
   // Persist selections when they change (only while results are showing)
   useEffect(() => {
@@ -812,6 +821,7 @@ export default function App() {
               onToggleGroup={handleToggleGroup}
               keptByGroupId={keptByGroupId}
               onToggleKept={handleToggleKept}
+              bucketsSplit={state.bucketsSplit}
             />
           </>
         )}

--- a/tests/components/duplicate-groups.test.tsx
+++ b/tests/components/duplicate-groups.test.tsx
@@ -281,3 +281,35 @@ describe("DuplicateGroups — Spacebar preview", () => {
     expect(screen.queryByTestId("viewer-modal")).not.toBeInTheDocument()
   })
 })
+
+// ============================================================
+// Split-bucket caveat
+// ============================================================
+
+describe("split bucket notice", () => {
+  it("warns when timestamp buckets were split", () => {
+    wrap(<DuplicateGroups {...defaultProps} bucketsSplit={3} />)
+    const notice = screen.getByTestId("split-buckets-notice")
+    expect(notice).toBeInTheDocument()
+    expect(notice).toHaveTextContent(/3 large time groups/i)
+    expect(notice).toHaveTextContent(/may be missed/i)
+  })
+
+  it("uses singular wording for a single split group", () => {
+    wrap(<DuplicateGroups {...defaultProps} bucketsSplit={1} />)
+    expect(screen.getByTestId("split-buckets-notice")).toHaveTextContent(
+      /1 large time group was split/i
+    )
+  })
+
+  it("shows nothing when no buckets were split", () => {
+    wrap(<DuplicateGroups {...defaultProps} bucketsSplit={0} />)
+    expect(screen.queryByTestId("split-buckets-notice")).not.toBeInTheDocument()
+  })
+
+  // Results saved before this field existed load without it.
+  it("shows nothing when bucketsSplit is absent", () => {
+    wrap(<DuplicateGroups {...defaultProps} />)
+    expect(screen.queryByTestId("split-buckets-notice")).not.toBeInTheDocument()
+  })
+})

--- a/tests/lib/app-reducer.test.ts
+++ b/tests/lib/app-reducer.test.ts
@@ -295,3 +295,74 @@ describe("RESET", () => {
     expect(next).toEqual({ status: "connecting" })
   })
 })
+
+// ============================================================
+// bucketsSplit — the "some duplicates may be missed" caveat
+// ============================================================
+
+const scanningState: AppState = {
+  status: "scanning",
+  phase: "fetching",
+  itemsProcessed: 0,
+  totalEstimate: 0,
+  message: "",
+  requestId: "r",
+  hasGptk: true,
+}
+
+describe("bucketsSplit", () => {
+  it("carries bucketsSplit from SCAN_COMPLETE into results", () => {
+    const next = appReducer(scanningState, {
+      type: "SCAN_COMPLETE",
+      mediaItems,
+      groups,
+      bucketsSplit: 3,
+    })
+    expect(next).toMatchObject({ status: "results", bucketsSplit: 3 })
+  })
+
+  it("defaults bucketsSplit to 0 when SCAN_COMPLETE omits it", () => {
+    const next = appReducer(scanningState, {
+      type: "SCAN_COMPLETE",
+      mediaItems,
+      groups,
+    })
+    expect(next).toMatchObject({ status: "results", bucketsSplit: 0 })
+  })
+
+  it("restores bucketsSplit from saved results", () => {
+    const next = appReducer(resultsState, {
+      type: "LOAD_SAVED_RESULTS",
+      mediaItems,
+      groups,
+      totalItems: 4,
+      bucketsSplit: 2,
+    })
+    expect(next).toMatchObject({ status: "results", bucketsSplit: 2 })
+  })
+
+  // The caveat is about scan completeness, so it must survive a trash round
+  // trip — the group list is still on screen throughout.
+  it("preserves bucketsSplit through TRASH_STARTED and TRASH_COMPLETE", () => {
+    const withSplit = appReducer(scanningState, {
+      type: "SCAN_COMPLETE",
+      mediaItems,
+      groups,
+      bucketsSplit: 5,
+    })
+    const trashing = appReducer(withSplit, {
+      type: "TRASH_STARTED",
+      totalToTrash: 2,
+      mediaItems,
+      groups,
+      totalItems: 4,
+    })
+    expect(trashing).toMatchObject({ status: "trashing", bucketsSplit: 5 })
+
+    const done = appReducer(trashing, {
+      type: "TRASH_COMPLETE",
+      trashedKeys: ["img2"],
+    })
+    expect(done).toMatchObject({ status: "results", bucketsSplit: 5 })
+  })
+})

--- a/tests/lib/duplicate-detector.test.ts
+++ b/tests/lib/duplicate-detector.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { communityDetection, matMul, topK, groupByTimestamp, withinGroupDuplicates, selectDefaultKeep, fullDetectDuplicates, dedupeByDedupKey } from "../../lib/duplicate-detector"
+import { communityDetection, matMul, topK, groupByTimestamp, withinGroupDuplicates, selectDefaultKeep, fullDetectDuplicates, dedupeByDedupKey, splitOversizedBuckets, MAX_BUCKET_SIZE } from "../../lib/duplicate-detector"
 import type { GpdMediaItem } from "../../lib/types"
 
 // ============================================================
@@ -327,6 +327,140 @@ describe("groupByTimestamp", () => {
     // a floors to 0, b floors to 1000
     const result = groupByTimestamp([a, b], 1000)
     expect(result).toHaveLength(0)
+  })
+
+  // Degenerate timestamps must not collapse into a single giant bucket.
+  // Math.floor(undefined / w) is NaN, and Map treats every NaN as the same
+  // key — so without a guard every such item lands in one bucket and the
+  // pairwise comparison there is quadratic in the whole library.
+  it("excludes items with an undefined timestamp instead of bucketing them together", () => {
+    const items = [
+      makeItem("a", undefined as unknown as number),
+      makeItem("b", undefined as unknown as number),
+      makeItem("c", undefined as unknown as number),
+    ]
+    expect(groupByTimestamp(items, 1000)).toHaveLength(0)
+  })
+
+  it("excludes items with a NaN timestamp", () => {
+    const items = [makeItem("a", NaN), makeItem("b", NaN)]
+    expect(groupByTimestamp(items, 1000)).toHaveLength(0)
+  })
+
+  // null / 1000 === 0, so these would silently join the epoch bucket.
+  it("excludes items with a null timestamp instead of putting them in the epoch bucket", () => {
+    const items = [
+      makeItem("a", null as unknown as number),
+      makeItem("b", null as unknown as number),
+      makeItem("real", 0),
+    ]
+    expect(groupByTimestamp(items, 1000)).toHaveLength(0)
+  })
+
+  it("still buckets valid timestamps when degenerate ones are present", () => {
+    const items = [
+      makeItem("a", 1000),
+      makeItem("b", 1000),
+      makeItem("bad", undefined as unknown as number),
+    ]
+    const result = groupByTimestamp(items, 1000)
+    expect(result).toHaveLength(1)
+    expect(result[0].map((i) => i.mediaKey).sort()).toEqual(["a", "b"])
+  })
+})
+
+// ============================================================
+// splitOversizedBuckets
+// ============================================================
+
+describe("splitOversizedBuckets", () => {
+  /** A bucket of `n` items with strictly increasing timestamps. */
+  const bucketOf = (n: number, prefix = "i", startTs = 0) =>
+    Array.from({ length: n }, (_, k) => makeItem(`${prefix}${k}`, startTs + k))
+
+  it("leaves a bucket at the cap untouched", () => {
+    const bucket = bucketOf(10)
+    const result = splitOversizedBuckets([bucket], 10)
+    expect(result.buckets).toHaveLength(1)
+    expect(result.buckets[0]).toEqual(bucket)
+    expect(result.bucketsSplit).toBe(0)
+  })
+
+  it("leaves a bucket under the cap untouched", () => {
+    const result = splitOversizedBuckets([bucketOf(3)], 10)
+    expect(result.buckets).toHaveLength(1)
+    expect(result.bucketsSplit).toBe(0)
+  })
+
+  it("splits an oversized bucket into ceil(length / cap) chunks", () => {
+    const result = splitOversizedBuckets([bucketOf(25)], 10)
+    expect(result.buckets).toHaveLength(3) // ceil(25/10)
+    expect(result.bucketsSplit).toBe(1)
+  })
+
+  // A fixed-size split would make 5000 + 1; near-equal makes 2500 + 2501.
+  it("splits into near-equal chunks rather than cap-sized ones", () => {
+    const result = splitOversizedBuckets([bucketOf(11)], 10)
+    expect(result.buckets).toHaveLength(2)
+    const sizes = result.buckets.map((b) => b.length).sort((a, b) => a - b)
+    expect(sizes[1] - sizes[0]).toBeLessThanOrEqual(1)
+  })
+
+  it("never produces a chunk larger than the cap", () => {
+    const result = splitOversizedBuckets([bucketOf(97)], 10)
+    for (const b of result.buckets) expect(b.length).toBeLessThanOrEqual(10)
+  })
+
+  it("loses no items when splitting", () => {
+    const bucket = bucketOf(25)
+    const result = splitOversizedBuckets([bucket], 10)
+    const keys = result.buckets.flat().map((i) => i.mediaKey).sort()
+    expect(keys).toEqual(bucket.map((i) => i.mediaKey).sort())
+  })
+
+  it("produces time-contiguous chunks even when input is unordered", () => {
+    // Shuffled timestamps — chunks must still be contiguous in time so that
+    // near-in-time duplicates stay in the same chunk.
+    const bucket = [
+      makeItem("e", 50),
+      makeItem("a", 10),
+      makeItem("d", 40),
+      makeItem("b", 20),
+      makeItem("c", 30),
+      makeItem("f", 60),
+    ]
+    const result = splitOversizedBuckets([bucket], 3)
+    expect(result.buckets).toHaveLength(2)
+    expect(result.buckets[0].map((i) => i.mediaKey)).toEqual(["a", "b", "c"])
+    expect(result.buckets[1].map((i) => i.mediaKey)).toEqual(["d", "e", "f"])
+  })
+
+  it("counts split source buckets, not resulting chunks", () => {
+    const result = splitOversizedBuckets([bucketOf(25, "x"), bucketOf(30, "y")], 10)
+    // 3 chunks + 3 chunks = 6 buckets out, but only 2 were split
+    expect(result.buckets).toHaveLength(6)
+    expect(result.bucketsSplit).toBe(2)
+  })
+
+  it("splits only the oversized buckets in a mixed set", () => {
+    const small = bucketOf(2, "s")
+    const big = bucketOf(25, "b")
+    const result = splitOversizedBuckets([small, big], 10)
+    expect(result.bucketsSplit).toBe(1)
+    expect(result.buckets).toContainEqual(small)
+    expect(result.buckets).toHaveLength(4) // 1 small + 3 chunks
+  })
+
+  it("handles an empty bucket list", () => {
+    const result = splitOversizedBuckets([], 10)
+    expect(result.buckets).toEqual([])
+    expect(result.bucketsSplit).toBe(0)
+  })
+
+  it("defaults to MAX_BUCKET_SIZE when no cap is given", () => {
+    const result = splitOversizedBuckets([bucketOf(MAX_BUCKET_SIZE + 1)])
+    expect(result.bucketsSplit).toBe(1)
+    expect(result.buckets).toHaveLength(2)
   })
 })
 

--- a/workers/embedder.worker.ts
+++ b/workers/embedder.worker.ts
@@ -159,8 +159,11 @@ self.addEventListener("message", async (event: MessageEvent) => {
       for (const [, members] of components)
         if (members.length >= 2) allGroups.push(members);
 
-      if (bi % 100 === 0)
-        self.postMessage({ type: "detectionProgress", current: bi + 1, total: buckets.length });
+      // Report every bucket, not every 100th. Buckets are capped upstream
+      // (see MAX_BUCKET_SIZE), but comparison cost is quadratic in bucket
+      // size, so a batch of 100 large buckets could otherwise leave the
+      // progress bar frozen for minutes with the scan looking hung.
+      self.postMessage({ type: "detectionProgress", current: bi + 1, total: buckets.length });
     }
 
     self.postMessage({ type: "detectionResults", groups: allGroups });


### PR DESCRIPTION
Smart mode compares every pair within a timestamp bucket, which is quadratic in bucket size. With a wide time window a single dense hour — a burst-shoot, a wedding, a bulk import — can put tens of thousands of photos into one bucket. At the measured worker rate a 50,000-item bucket takes ~34 minutes, and since progress was only posted every 100 buckets, the scan looked hung the whole time.

This caps buckets at `MAX_BUCKET_SIZE` (5,000), splitting oversized ones into near-equal, time-contiguous chunks. Sorting by timestamp before chunking keeps near-in-time photos together, where duplicates actually cluster.

It's a deliberate trade: duplicates straddling a chunk boundary are missed, so the number of split buckets is reported through to the results page as an explicit caveat and persists with saved results.

Also guards non-finite timestamps in `groupByTimestamp`. An `undefined` timestamp produced a `NaN` key, and since `Map` treats every `NaN` as the same key, all such items collapsed into a single bucket; `null` floored to `0` and silently joined the epoch bucket. Both defeat the cap.

Progress is now posted every bucket rather than every 100th.

On a synthetic 121k-item library (40k sparse plus 8k/20k/50k bursts each landing in one 1-hour bucket):

| | before | after |
|---|---|---|
| worst single bucket | 34.1 min | 16.9 s |
| total pairwise time | 40.4 min | 4.63 min |

No items lost. 23 new tests (248 total, up from 225); `tsc --noEmit` clean.