### PR TITLE
feat: allow similarity threshold down to 0.75

### DIFF
--- a/components/DuplicateGroups.tsx
+++ b/components/DuplicateGroups.tsx
@@ -12,6 +12,7 @@ import Paper from "@mui/material/Paper"
 import Skeleton from "@mui/material/Skeleton"
 import Typography from "@mui/material/Typography"
 import OpenInFullIcon from "@mui/icons-material/OpenInFull"
+import StarIcon from "@mui/icons-material/Star"
 import { useBlobUrl } from "./useBlobUrl"
 import { PhotoViewerModal } from "./PhotoViewerModal"
 import { buildThumbUrl } from "../lib/photo-url"
@@ -79,6 +80,23 @@ const sxViewerBtn = {
   "&:hover": { bgcolor: "rgba(0,0,0,0.65)" },
 }
 const sxOpenInFullIcon = { fontSize: 14 }
+// Mirrors sxViewerBtn's translucent pill so the two overlays read as one
+// language, but sits top-left since the zoom button owns top-right.
+const sxFavoriteBadge = {
+  position: "absolute",
+  top: 4,
+  left: 4,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 24,
+  height: 24,
+  borderRadius: "50%",
+  bgcolor: "rgba(0,0,0,0.45)",
+  color: "#FFC107",
+  pointerEvents: "none",
+}
+const sxFavoriteIcon = { fontSize: 15 }
 const sxStatusChip = { width: "fit-content", height: 20, fontSize: 11 }
 // ──────────────────────────────────────────────────────────────────────
 
@@ -251,6 +269,21 @@ const DuplicateGroupRow = memo(function DuplicateGroupRow({
                   </CardContent>
                 </CardActionArea>
               </Card>
+
+              {/*
+                Favorite marker. Purely informational — it reports Google
+                Photos state we cannot change from here, so it is not a
+                control and does not swallow the card's keep/trash click.
+              */}
+              {item.isFavorite === true && (
+                <Box
+                  sx={sxFavoriteBadge}
+                  data-testid={`favorite-badge-${key}`}
+                  title="Favorite in Google Photos — kept by default"
+                  aria-label="Favorite in Google Photos">
+                  <StarIcon sx={sxFavoriteIcon} />
+                </Box>
+              )}
 
               {/* Zoom overlay — secondary action, does not trigger Keep toggle */}
               <IconButton

--- a/components/DuplicateGroups.tsx
+++ b/components/DuplicateGroups.tsx
@@ -13,10 +13,13 @@ import Skeleton from "@mui/material/Skeleton"
 import Typography from "@mui/material/Typography"
 import OpenInFullIcon from "@mui/icons-material/OpenInFull"
 import StarIcon from "@mui/icons-material/Star"
+import DeleteSweepIcon from "@mui/icons-material/DeleteSweep"
+import Tooltip from "@mui/material/Tooltip"
 import { useBlobUrl } from "./useBlobUrl"
 import { PhotoViewerModal } from "./PhotoViewerModal"
 import { buildThumbUrl } from "../lib/photo-url"
 import type { GpdMediaItem, DuplicateGroup } from "../lib/types"
+import { isWholeGroupTrashed } from "../lib/kept-overrides"
 
 const PAGE_SIZE = 30
 
@@ -145,6 +148,7 @@ interface DuplicateGroupRowProps {
   keptSet: Set<string>
   onToggleGroup: (groupId: string) => void
   onToggleKept: (group: DuplicateGroup, mediaKey: string) => void
+  onTrashWholeGroup: (group: DuplicateGroup) => void
   onOpenViewer: (group: DuplicateGroup, index: number) => void
   onMouseEnterPhoto: (group: DuplicateGroup, index: number) => void
   onMouseLeavePhoto: () => void
@@ -157,10 +161,12 @@ const DuplicateGroupRow = memo(function DuplicateGroupRow({
   keptSet,
   onToggleGroup,
   onToggleKept,
+  onTrashWholeGroup,
   onOpenViewer,
   onMouseEnterPhoto,
   onMouseLeavePhoto,
 }: DuplicateGroupRowProps) {
+  const allTrashed = isWholeGroupTrashed(keptSet)
   return (
     <Paper
       variant="outlined"
@@ -185,6 +191,30 @@ const DuplicateGroupRow = memo(function DuplicateGroupRow({
           variant="outlined"
           sx={sxChipSimilarity}
         />
+        <Tooltip
+          title={
+            allTrashed
+              ? "Keep the best photo again"
+              : "Trash every photo in this group"
+          }>
+          {/* stopPropagation: the header itself toggles group selection */}
+          <IconButton
+            size="small"
+            data-testid={`trash-whole-group-${group.id}`}
+            aria-label={
+              allTrashed
+                ? "Keep the best photo in this group"
+                : "Trash every photo in this group"
+            }
+            aria-pressed={allTrashed}
+            color={allTrashed ? "error" : "default"}
+            onClick={(e) => {
+              e.stopPropagation()
+              onTrashWholeGroup(group)
+            }}>
+            <DeleteSweepIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
       </Box>
 
       {/* Thumbnails */}
@@ -312,6 +342,7 @@ interface DuplicateGroupsProps {
   onToggleGroup: (groupId: string) => void
   keptByGroupId: Map<string, Set<string>>
   onToggleKept: (group: DuplicateGroup, mediaKey: string) => void
+  onTrashWholeGroup: (group: DuplicateGroup) => void
   /**
    * Timestamp buckets split during the scan to keep pairwise comparison
    * bounded. Above zero, results are incomplete and we say so.
@@ -326,6 +357,7 @@ export function DuplicateGroups({
   onToggleGroup,
   keptByGroupId,
   onToggleKept,
+  onTrashWholeGroup,
   bucketsSplit = 0,
 }: DuplicateGroupsProps) {
   // Measure time from first non-empty groups render to commit
@@ -469,6 +501,7 @@ export function DuplicateGroups({
           keptSet={keptByGroupId.get(group.id)!}
           onToggleGroup={onToggleGroup}
           onToggleKept={onToggleKept}
+          onTrashWholeGroup={onTrashWholeGroup}
           onOpenViewer={onOpenViewer}
           onMouseEnterPhoto={onMouseEnterPhoto}
           onMouseLeavePhoto={onMouseLeavePhoto}

--- a/components/DuplicateGroups.tsx
+++ b/components/DuplicateGroups.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import Alert from "@mui/material/Alert"
 import Box from "@mui/material/Box"
 import Card from "@mui/material/Card"
 import CardActionArea from "@mui/material/CardActionArea"
@@ -278,6 +279,11 @@ interface DuplicateGroupsProps {
   onToggleGroup: (groupId: string) => void
   keptByGroupId: Map<string, Set<string>>
   onToggleKept: (group: DuplicateGroup, mediaKey: string) => void
+  /**
+   * Timestamp buckets split during the scan to keep pairwise comparison
+   * bounded. Above zero, results are incomplete and we say so.
+   */
+  bucketsSplit?: number
 }
 
 export function DuplicateGroups({
@@ -287,6 +293,7 @@ export function DuplicateGroups({
   onToggleGroup,
   keptByGroupId,
   onToggleKept,
+  bucketsSplit = 0,
 }: DuplicateGroupsProps) {
   // Measure time from first non-empty groups render to commit
   const renderLoggedRef = useRef(false)
@@ -411,6 +418,14 @@ export function DuplicateGroups({
       <Typography variant="h6" fontWeight={600} sx={{ px: 0, py: 2 }}>
         {groups.length} Duplicate Group{groups.length !== 1 ? "s" : ""} Found
       </Typography>
+
+      {bucketsSplit > 0 && (
+        <Alert severity="info" data-testid="split-buckets-notice" sx={{ mb: 2 }}>
+          {bucketsSplit} large time {bucketsSplit === 1 ? "group was" : "groups were"} split
+          to keep the scan fast — duplicates spanning a split may be missed. Narrow the
+          time window to compare fewer photos at once.
+        </Alert>
+      )}
 
       {groups.slice(0, visibleCount).map((group) => (
         <DuplicateGroupRow

--- a/components/PhotoViewerModal.tsx
+++ b/components/PhotoViewerModal.tsx
@@ -3,6 +3,7 @@ import { keyframes } from "@emotion/react"
 import Box from "@mui/material/Box"
 import CardMedia from "@mui/material/CardMedia"
 import Chip from "@mui/material/Chip"
+import StarIcon from "@mui/icons-material/Star"
 import CircularProgress from "@mui/material/CircularProgress"
 import Dialog from "@mui/material/Dialog"
 import DialogContent from "@mui/material/DialogContent"
@@ -290,12 +291,22 @@ export function PhotoViewerModal({
           py: 0.5,
           borderBottom: "1px solid rgba(255,255,255,0.1)",
         }}>
-        <Typography
-          variant="caption"
-          noWrap
-          sx={{ color: "rgba(255,255,255,0.45)", pl: 1 }}>
-          {item.fileName || ""}
-        </Typography>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, pl: 1, minWidth: 0 }}>
+          {/* Informational only — favorites cannot be changed from here. */}
+          {item.isFavorite === true && (
+            <StarIcon
+              data-testid="viewer-favorite-badge"
+              titleAccess="Favorite in Google Photos"
+              sx={{ fontSize: 14, color: "#FFC107", flexShrink: 0 }}
+            />
+          )}
+          <Typography
+            variant="caption"
+            noWrap
+            sx={{ color: "rgba(255,255,255,0.45)" }}>
+            {item.fileName || ""}
+          </Typography>
+        </Box>
 
         {/* Counter — centered, prominent, slides on navigation */}
         {items.length > 1 && (

--- a/components/ScanConfig.tsx
+++ b/components/ScanConfig.tsx
@@ -141,8 +141,15 @@ export function ScanConfig({
                 Similarity Threshold:{" "}
                 <strong>{settings.similarityThreshold}</strong>
               </Typography>
+              {/*
+                The floor is deliberately below the useful range for exact
+                duplicates. Down here MobileNet groups photos that are merely
+                similar — different frames of a burst, the same scene with a
+                different subject — which is useful for culling but produces
+                false positives, so the keep/trash review matters more.
+              */}
               <Slider
-                min={0.9}
+                min={0.75}
                 max={1.0}
                 step={0.01}
                 value={settings.similarityThreshold}

--- a/components/ScanProgress.tsx
+++ b/components/ScanProgress.tsx
@@ -12,6 +12,10 @@ interface ScanProgressProps {
   totalEstimate: number
   message: string
   onCancel?: () => void
+  /** Upload date of the oldest item fetched so far; walks backwards monotonically. */
+  oldestUploadedAt?: number
+  /** Taken date of that same item. Often diverges from the upload date. */
+  oldestTakenAt?: number
 }
 
 const PHASE_LABELS: Record<ScanPhase, string> = {
@@ -44,12 +48,28 @@ function formatEtr(seconds: number): string {
   return mins > 0 ? `${hrs}h ${mins}m remaining` : `${hrs}h remaining`
 }
 
+/**
+ * Format a timestamp for the fetch-position readout, or null when the value is
+ * unusable. Some items carry no date at all; rendering those as 1 Jan 1970
+ * would be worse than showing nothing.
+ */
+function formatPositionDate(ts: number | undefined): string | null {
+  if (ts === undefined || !Number.isFinite(ts) || ts <= 0) return null
+  return new Date(ts).toLocaleDateString(undefined, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  })
+}
+
 export function ScanProgress({
   phase,
   itemsProcessed,
   totalEstimate,
   message,
   onCancel,
+  oldestUploadedAt,
+  oldestTakenAt,
 }: ScanProgressProps) {
   const progress =
     totalEstimate > 0 ? Math.round((itemsProcessed / totalEstimate) * 100) : 0
@@ -81,6 +101,10 @@ export function ScanProgress({
 
   const etaText = cachedEtrRef.current?.text ?? null
   const stepNum = PHASE_STEP[phase]
+
+  // Only meaningful while paginating; later phases work on a fixed set.
+  const uploadedText = phase === "fetching" ? formatPositionDate(oldestUploadedAt) : null
+  const takenText = phase === "fetching" ? formatPositionDate(oldestTakenAt) : null
 
   return (
     <Box sx={{ maxWidth: 480, mx: "auto", p: 4 }}>
@@ -117,6 +141,17 @@ export function ScanProgress({
           </Typography>
         )}
       </Box>
+
+      {uploadedText && (
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          data-testid="fetch-position"
+          sx={{ display: "block", mb: 2 }}>
+          Reached uploads from {uploadedText}
+          {takenText && ` (taken ${takenText})`}
+        </Typography>
+      )}
 
       {onCancel && (
         <Box sx={{ mt: 3 }}>

--- a/lib/app-reducer.ts
+++ b/lib/app-reducer.ts
@@ -26,6 +26,10 @@ export type AppState =
       message: string
       requestId: string
       hasGptk: boolean
+      // How far back the fetch has reached. Upload date walks backwards
+      // monotonically; taken date does not. Undefined until the first page.
+      oldestUploadedAt?: number
+      oldestTakenAt?: number
       accountEmail?: string
     }
   | {
@@ -144,6 +148,14 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         itemsProcessed: action.payload.itemsProcessed,
         ...(action.totalItems !== undefined ? { totalEstimate: action.totalItems } : {}),
         message: action.payload.message || state.message,
+        // Spread only when present so a later message without dates does not
+        // blank out a position already on screen.
+        ...(action.payload.oldestUploadedAt !== undefined
+          ? { oldestUploadedAt: action.payload.oldestUploadedAt }
+          : {}),
+        ...(action.payload.oldestTakenAt !== undefined
+          ? { oldestTakenAt: action.payload.oldestTakenAt }
+          : {}),
       }
 
     case "SCAN_MEDIA_FETCHED":

--- a/lib/app-reducer.ts
+++ b/lib/app-reducer.ts
@@ -33,6 +33,10 @@ export type AppState =
       mediaItems: Record<string, GpdMediaItem>
       groups: DuplicateGroup[]
       totalItems: number
+      // How many timestamp buckets were split to bound comparison cost.
+      // > 0 means some duplicates spanning a split may not have been found.
+      // Optional: results persisted before this existed won't carry it.
+      bucketsSplit?: number
       accountEmail?: string
     }
   | {
@@ -42,6 +46,7 @@ export type AppState =
       totalItems: number
       totalToTrash: number
       trashedSoFar: number
+      bucketsSplit?: number
       accountEmail?: string
     }
 
@@ -54,6 +59,7 @@ export type AppAction =
       type: "SCAN_COMPLETE"
       mediaItems: Record<string, GpdMediaItem>
       groups: DuplicateGroup[]
+      bucketsSplit?: number
     }
   | { type: "SCAN_ERROR"; error: string }
   | { type: "SCAN_CANCELLED" }
@@ -72,6 +78,7 @@ export type AppAction =
       mediaItems: Record<string, GpdMediaItem>
       groups: DuplicateGroup[]
       totalItems: number
+      bucketsSplit?: number
       accountEmail?: string
     }
   | {
@@ -155,6 +162,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         mediaItems: action.mediaItems,
         groups: action.groups,
         totalItems: Object.keys(action.mediaItems).length,
+        bucketsSplit: action.bucketsSplit ?? 0,
         accountEmail: "accountEmail" in state ? state.accountEmail : undefined,
       }
 
@@ -173,6 +181,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         totalItems: action.totalItems,
         totalToTrash: action.totalToTrash,
         trashedSoFar: 0,
+        bucketsSplit: "bucketsSplit" in state ? state.bucketsSplit : 0,
         accountEmail: "accountEmail" in state ? state.accountEmail : undefined,
       }
 
@@ -200,6 +209,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         mediaItems: newMediaItems,
         groups: newGroups,
         totalItems: state.totalItems,
+        bucketsSplit: state.bucketsSplit,
         accountEmail: state.accountEmail,
       }
     }
@@ -213,6 +223,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         mediaItems: action.mediaItems,
         groups: action.groups,
         totalItems: action.totalItems,
+        bucketsSplit: action.bucketsSplit ?? 0,
         accountEmail: action.accountEmail,
       }
 
@@ -222,6 +233,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         mediaItems: action.mediaItems,
         groups: action.groups,
         totalItems: action.totalItems,
+        bucketsSplit: "bucketsSplit" in state ? state.bucketsSplit : 0,
         accountEmail: "accountEmail" in state ? state.accountEmail : undefined,
       }
 

--- a/lib/duplicate-detector.ts
+++ b/lib/duplicate-detector.ts
@@ -13,12 +13,20 @@ import type { ScanLogger } from "./scan-log";
 
 /**
  * Select the best item to keep from a duplicate group.
- * Priority: original quality > higher resolution > oldest upload date.
+ * Priority: favorited > original quality > higher resolution > oldest upload date.
+ *
+ * Favorites outrank every quality heuristic. Starring a photo is an explicit
+ * signal from the user, which beats anything we can infer, and silently
+ * trashing a favorite is the worst outcome this tool can produce. When a group
+ * has several favorites — or none — the remaining criteria decide as before.
  */
 export function selectDefaultKeep(items: GpdMediaItem[]): string {
   const qualityScore = (x: GpdMediaItem) =>
     x.isOriginalQuality === true ? 2 : x.isOriginalQuality === false ? 0 : 1;
+  const favoriteScore = (x: GpdMediaItem) => (x.isFavorite === true ? 1 : 0);
   const best = [...items].sort((a, b) => {
+    const favDiff = favoriteScore(b) - favoriteScore(a);
+    if (favDiff !== 0) return favDiff;
     const qDiff = qualityScore(b) - qualityScore(a);
     if (qDiff !== 0) return qDiff;
     const pxDiff =

--- a/lib/duplicate-detector.ts
+++ b/lib/duplicate-detector.ts
@@ -354,6 +354,12 @@ export function groupByTimestamp(
 ): GpdMediaItem[][] {
   const buckets = new Map<number, GpdMediaItem[]>();
   for (const item of items) {
+    // Guard degenerate timestamps. `undefined` floors to NaN and Map treats
+    // every NaN as the same key; `null` floors to 0 and silently joins the
+    // epoch bucket. Either way every affected item collapses into one bucket,
+    // whose pairwise comparison is quadratic in the size of that collapse.
+    // Such items can't be time-matched anyway, so drop them from bucketing.
+    if (!Number.isFinite(item.timestamp)) continue;
     const key =
       windowMs > 0
         ? Math.floor(item.timestamp / windowMs) * windowMs
@@ -362,6 +368,54 @@ export function groupByTimestamp(
     buckets.get(key)!.push(item);
   }
   return [...buckets.values()].filter((g) => g.length >= 2);
+}
+
+/**
+ * Largest timestamp bucket we will compare pairwise in one piece.
+ *
+ * Comparison cost is quadratic in bucket size, so a single dense bucket can
+ * dominate an entire scan: at the measured worker throughput a 5,000-item
+ * bucket takes roughly 20 seconds, while a 50,000-item one takes over half an
+ * hour. Wide time windows make this easy to hit — one busy hour or a bulk
+ * import can drop thousands of photos into the same bucket.
+ */
+export const MAX_BUCKET_SIZE = 5000;
+
+/**
+ * Split buckets larger than `cap` into smaller, time-contiguous chunks so no
+ * single pairwise comparison runs unbounded.
+ *
+ * Chunks are near-equal rather than cap-sized — splitting 5,001 items at a cap
+ * of 5,000 yields 2,501 + 2,500, not 5,000 + 1. Items are sorted by timestamp
+ * first so each chunk covers a contiguous slice of time, which is where real
+ * duplicates cluster.
+ *
+ * This trades recall for a bounded runtime: duplicates that straddle a chunk
+ * boundary are not detected. `bucketsSplit` counts how many source buckets
+ * were affected so the UI can say so.
+ */
+export function splitOversizedBuckets(
+  buckets: GpdMediaItem[][],
+  cap = MAX_BUCKET_SIZE,
+): { buckets: GpdMediaItem[][]; bucketsSplit: number } {
+  const out: GpdMediaItem[][] = [];
+  let bucketsSplit = 0;
+
+  for (const bucket of buckets) {
+    if (bucket.length <= cap) {
+      out.push(bucket);
+      continue;
+    }
+    bucketsSplit++;
+
+    const sorted = [...bucket].sort((a, b) => a.timestamp - b.timestamp);
+    const chunkCount = Math.ceil(sorted.length / cap);
+    const chunkSize = Math.ceil(sorted.length / chunkCount);
+    for (let i = 0; i < sorted.length; i += chunkSize)
+      out.push(sorted.slice(i, i + chunkSize));
+  }
+
+  return { buckets: out, bucketsSplit };
 }
 
 /**
@@ -489,7 +543,7 @@ export async function smartDetectDuplicates(
   onProgress?: ProgressCallback,
   signal?: AbortSignal,
   logger?: ScanLogger,
-): Promise<DuplicateGroup[]> {
+): Promise<{ groups: DuplicateGroup[]; bucketsSplit: number }> {
   const scanStart = performance.now();
 
   const dedupedItems = dedupeByDedupKey(mediaItems);
@@ -500,11 +554,16 @@ export async function smartDetectDuplicates(
   const candidates = dedupedItems.filter((item) => item.thumb);
 
   // Step 1: Bucket by timestamp — no I/O, instant
-  const buckets = groupByTimestamp(candidates, windowMs);
+  const rawBuckets = groupByTimestamp(candidates, windowMs);
+
+  // Step 1b: Cap bucket size. Pairwise cost is quadratic within a bucket, so
+  // one dense hour can otherwise stall the whole scan.
+  const { buckets, bucketsSplit } = splitOversizedBuckets(rawBuckets);
+  const largest = buckets.reduce((max, b) => Math.max(max, b.length), 0);
   console.log(
-    `[GPD] smartDetectDuplicates: ${mediaItems.length} items → ${candidates.length} candidates → ${buckets.length} timestamp buckets`,
+    `[GPD] smartDetectDuplicates: ${mediaItems.length} items → ${candidates.length} candidates → ${buckets.length} timestamp buckets (largest ${largest}${bucketsSplit > 0 ? `, ${bucketsSplit} split at cap ${MAX_BUCKET_SIZE}` : ""})`,
   );
-  if (buckets.length === 0) return [];
+  if (buckets.length === 0) return { groups: [], bucketsSplit };
 
   // Flatten to deduplicated subset
   const seen = new Set<string>();
@@ -570,7 +629,7 @@ export async function smartDetectDuplicates(
   );
   await logger?.phaseComplete("computeEmbeddingsMs", computeEmbeddingsMs);
 
-  if (embeddings.length < 2) return [];
+  if (embeddings.length < 2) return { groups: [], bucketsSplit };
 
   // Build bucket index arrays (indices into embeddings[])
   const mediaKeyToEmbIdx = new Map<string, number>();
@@ -585,7 +644,7 @@ export async function smartDetectDuplicates(
     )
     .filter((b) => b.length >= 2);
 
-  if (workerBuckets.length === 0) return [];
+  if (workerBuckets.length === 0) return { groups: [], bucketsSplit };
 
   // Offload pairwise comparison to worker
   trackedProgress({ phase: "detecting_duplicates", current: 0, total: 0 });
@@ -621,7 +680,10 @@ export async function smartDetectDuplicates(
     };
   });
 
-  return groups.sort((a, b) => b.mediaKeys.length - a.mediaKeys.length);
+  return {
+    groups: groups.sort((a, b) => b.mediaKeys.length - a.mediaKeys.length),
+    bucketsSplit,
+  };
 }
 
 // ============================================================

--- a/lib/kept-overrides.ts
+++ b/lib/kept-overrides.ts
@@ -1,0 +1,56 @@
+// Per-group "kept" overrides.
+//
+// Every group normally keeps at least one item — selectDefaultKeep picks it,
+// and the per-photo toggle refuses to remove the last one. Trashing a whole
+// group is the deliberate exception, represented by an override holding an
+// empty set. That distinction matters: an absent override means "use the
+// default keep", while an empty one means "keep nothing".
+
+import type { DuplicateGroup } from "./types";
+
+export type KeptOverrides = Record<string, Set<string>>;
+
+/**
+ * True when this group is set to keep nothing, i.e. every item in it will be
+ * trashed. An undefined set means no override, which always keeps one item.
+ */
+export function isWholeGroupTrashed(keptSet: Set<string> | undefined): boolean {
+  return keptSet !== undefined && keptSet.size === 0;
+}
+
+/**
+ * Toggle a group between "trash everything" and the default keep.
+ *
+ * Toggling back removes the override rather than restoring a remembered
+ * selection, so the current default — which prefers favorites — applies again
+ * instead of freezing a stale choice.
+ */
+export function toggleWholeGroupTrashed(
+  overrides: KeptOverrides,
+  groupId: string,
+): KeptOverrides {
+  if (isWholeGroupTrashed(overrides[groupId])) {
+    const next = { ...overrides };
+    delete next[groupId];
+    return next;
+  }
+  return { ...overrides, [groupId]: new Set<string>() };
+}
+
+/**
+ * How many of the groups selected for trashing would be removed entirely.
+ * Used to warn in the confirmation dialog, where "move N duplicates to trash"
+ * reads very differently if some groups leave no survivor.
+ */
+export function countFullyTrashedGroups(
+  groups: DuplicateGroup[],
+  selectedGroupIds: Set<string>,
+  keptFor: (group: DuplicateGroup) => Set<string>,
+): number {
+  let count = 0;
+  for (const group of groups) {
+    if (!selectedGroupIds.has(group.id)) continue;
+    if (keptFor(group).size === 0) count++;
+  }
+  return count;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -120,6 +120,18 @@ export interface GptkProgressMessage extends BaseMessage {
   message?: string;
   /** Set by batch operations (e.g. "trashItems") so the app can route progress correctly. */
   command?: string;
+  /**
+   * Upload date of the oldest item fetched so far. Pagination runs newest-first
+   * by upload date, so this walks backwards monotonically and is the honest
+   * indicator of how far through the library the fetch has reached.
+   */
+  oldestUploadedAt?: number;
+  /**
+   * Taken date of that same item. Shown alongside the upload date because the
+   * two frequently diverge — a photo uploaded yesterday may have been taken
+   * decades ago — and this does NOT decrease monotonically.
+   */
+  oldestTakenAt?: number;
 }
 
 export interface GptkLogMessage extends BaseMessage {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -177,6 +177,12 @@ export interface GpdMediaItem {
   size?: number;
   isOwned?: boolean;
   isOriginalQuality?: boolean | null;
+  /**
+   * Whether the user starred this item in Google Photos. Google omits the
+   * underlying field rather than sending false, so absent means "not
+   * favorited" — always test for `=== true`.
+   */
+  isFavorite?: boolean;
   duration?: number; // video duration (undefined for photos)
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -186,6 +186,10 @@ export interface StoredState {
     scanDate: number;
     totalItems: number;
     newestCreationTimestamp?: number; // for incremental fetch on next scan
+    // Timestamp buckets split to bound comparison cost; > 0 means the scan
+    // may have missed duplicates spanning a split. Absent on results saved
+    // before this was recorded.
+    bucketsSplit?: number;
     accountEmail?: string;
   };
   selections?: {

--- a/notes/2026-08-28-scan-fetch-position.md
+++ b/notes/2026-08-28-scan-fetch-position.md
@@ -1,0 +1,100 @@
+# Showing how far back the fetch has reached
+
+*2026-08-29T03:47:37Z by Showboat 0.6.1*
+<!-- showboat-id: 8a9affe7-ea64-4c2c-94ff-00cdf608e554 -->
+
+## What was already there
+
+`ScanProgress` already rendered a live item count during the fetch phase, fed by
+`postProgress(requestId, mediaItems.length, ...)` in `getAllMediaItems`. So
+'show the current mediaItems size' needed no work.
+
+## What was missing
+
+Where in time the fetch has reached. A 100k-item library is roughly 400
+sequential pages; a climbing number alone says nothing about how much is left.
+
+## Which date to show
+
+Pagination uses `gptkApi.getItemsByUploadedDate`, newest-first **by upload
+date**. So the upload date of the last item on each page walks backwards
+monotonically and is the honest position indicator. The taken date does not — a
+photo uploaded yesterday may have been taken decades ago — so it is shown
+alongside rather than used as the position.
+
+Zero and non-finite timestamps are filtered at the source. Real libraries
+contain items with no usable date, and they would otherwise render as
+1 Jan 1970.
+
+```bash
+sed -n '/Report how far back/,/^      )$/p' scripts/google-photos-commands.js
+```
+
+```output
+      // Report how far back the fetch has reached. Items arrive newest-first by
+      // upload date, so the last item of the page is the oldest seen so far.
+      // Only finite, non-zero values are sent — some items carry no usable date
+      // and would otherwise render as 1 Jan 1970.
+      const oldest = mediaItems[mediaItems.length - 1]
+      const position = {}
+      if (oldest) {
+        if (Number.isFinite(oldest.creationTimestamp) && oldest.creationTimestamp > 0)
+          position.oldestUploadedAt = oldest.creationTimestamp
+        if (Number.isFinite(oldest.timestamp) && oldest.timestamp > 0)
+          position.oldestTakenAt = oldest.timestamp
+      }
+
+      postProgress(
+        requestId,
+        mediaItems.length,
+        `Fetched ${mediaItems.length} items`,
+        undefined,
+        position
+      )
+```
+
+## Rendered output
+
+The real `ScanProgress` component rendered with `renderToStaticMarkup`, tags
+stripped, to show the exact copy a user sees. Harness is throwaway and lives
+outside the repo, so this block will not reproduce on a later `showboat verify`.
+
+```bash
+node /private/tmp/claude-501/-Users-yakovv-marina-work-deduper/41396d94-0894-44a5-90dd-b4886ea0e177/scratchpad/render/out.cjs
+```
+
+```output
+
+--- mid-fetch, both dates present ---
+Scanning Library  ·  Fetching media items  ·  Step 1 of 4  ·  24,300 items processed  ·  Reached uploads from Mar 12, 2023 (taken Jul 4, 2019)
+
+--- mid-fetch, taken date missing ---
+Scanning Library  ·  Fetching media items  ·  Step 1 of 4  ·  24,300 items processed  ·  Reached uploads from Mar 12, 2023
+
+--- first page not yet returned ---
+Scanning Library  ·  Fetching media items  ·  Step 1 of 4  ·  0 items processed
+
+--- later phase: position suppressed ---
+Scanning Library  ·  Computing image similarity  ·  Step 3 of 4  ·  500 items processed
+
+```
+
+## Tests
+
+15 new tests (263 total, up from 248). The four covering
+`scripts/google-photos-commands.js` were written after the implementation, so
+they were verified red by reverting the script to HEAD and re-running: 3 of 4
+failed, the fourth asserts absence and passes either way.
+
+```bash
+npx tsc --noEmit -p tsconfig.json && echo 'typecheck: clean' && npm test 2>&1 | tail -5
+```
+
+```output
+typecheck: clean
+ Test Files  13 passed (13)
+      Tests  263 passed (263)
+   Start at  20:48:12
+   Duration  1.74s (transform 1.19s, setup 1.03s, import 3.06s, tests 2.22s, environment 3.91s)
+
+```

--- a/notes/2026-08-28-smart-detect-bucket-cap.md
+++ b/notes/2026-08-28-smart-detect-bucket-cap.md
@@ -1,0 +1,168 @@
+# Capping oversized timestamp buckets in smart detection
+
+*2026-08-28T22:16:06Z by Showboat 0.6.1*
+<!-- showboat-id: e20fb666-0668-4b2a-bac9-7d4371e3c0f3 -->
+
+## The problem
+
+Smart mode buckets photos by timestamp, then compares every pair *within* each
+bucket. That cost is quadratic in bucket size. With a wide time window (the 1h
+setting), one dense hour — a wedding, a burst-shoot, a bulk import — drops
+thousands of photos into a single bucket and the scan appears to hang.
+
+It is not a frozen UI: detection runs in a worker, and cancel works because
+`runSmartDetectionInWorker` calls `worker.terminate()` on abort. The user-visible
+failure is that progress was only posted every 100 buckets, so a single huge
+bucket showed no movement at all for tens of minutes.
+
+Measured worker throughput is 6.26e8 multiply-adds/sec at dim=1024, which puts a
+50,000-item bucket at ~34 minutes.
+
+## The change
+
+`splitOversizedBuckets` caps any bucket at `MAX_BUCKET_SIZE` (5,000), splitting
+oversized ones into near-equal, time-contiguous chunks. This trades recall for a
+bounded runtime — duplicates straddling a chunk boundary are missed — so the
+count of split buckets is surfaced in the results UI.
+
+`groupByTimestamp` also now drops items whose timestamp is not finite. Previously
+`undefined` produced a `NaN` key, and since `Map` treats every `NaN` as the same
+key, all such items collapsed into one bucket; `null` floored to 0 and silently
+joined the epoch bucket.
+
+## Diff under test
+
+```bash
+git diff --stat
+```
+
+```output
+ components/DuplicateGroups.tsx             |  15 ++++
+ lib/app-reducer.ts                         |  12 +++
+ lib/duplicate-detector.ts                  |  76 ++++++++++++++--
+ lib/types.ts                               |   4 +
+ package-lock.json                          |   2 +
+ tabs/app.tsx                               |  18 +++-
+ tests/components/duplicate-groups.test.tsx |  32 +++++++
+ tests/lib/app-reducer.test.ts              |  71 +++++++++++++++
+ tests/lib/duplicate-detector.test.ts       | 136 ++++++++++++++++++++++++++++-
+ workers/embedder.worker.ts                 |   7 +-
+ 10 files changed, 359 insertions(+), 14 deletions(-)
+```
+
+```bash
+sed -n '/^export const MAX_BUCKET_SIZE/,/^}/p' lib/duplicate-detector.ts
+```
+
+```output
+export const MAX_BUCKET_SIZE = 5000;
+
+/**
+ * Split buckets larger than `cap` into smaller, time-contiguous chunks so no
+ * single pairwise comparison runs unbounded.
+ *
+ * Chunks are near-equal rather than cap-sized — splitting 5,001 items at a cap
+ * of 5,000 yields 2,501 + 2,500, not 5,000 + 1. Items are sorted by timestamp
+ * first so each chunk covers a contiguous slice of time, which is where real
+ * duplicates cluster.
+ *
+ * This trades recall for a bounded runtime: duplicates that straddle a chunk
+ * boundary are not detected. `bucketsSplit` counts how many source buckets
+ * were affected so the UI can say so.
+ */
+export function splitOversizedBuckets(
+  buckets: GpdMediaItem[][],
+  cap = MAX_BUCKET_SIZE,
+): { buckets: GpdMediaItem[][]; bucketsSplit: number } {
+  const out: GpdMediaItem[][] = [];
+  let bucketsSplit = 0;
+
+  for (const bucket of buckets) {
+    if (bucket.length <= cap) {
+      out.push(bucket);
+      continue;
+    }
+    bucketsSplit++;
+
+    const sorted = [...bucket].sort((a, b) => a.timestamp - b.timestamp);
+    const chunkCount = Math.ceil(sorted.length / cap);
+    const chunkSize = Math.ceil(sorted.length / chunkCount);
+    for (let i = 0; i < sorted.length; i += chunkSize)
+      out.push(sorted.slice(i, i + chunkSize));
+  }
+
+  return { buckets: out, bucketsSplit };
+}
+```
+
+## Typecheck and full suite
+
+248 tests, up from 225 on the base commit — 23 new covering the split function,
+the non-finite timestamp guard, reducer plumbing, and the UI notice.
+
+```bash
+npx tsc --noEmit -p tsconfig.json && echo 'typecheck: clean' && npm test 2>&1 | tail -6
+```
+
+```output
+typecheck: clean
+
+ Test Files  13 passed (13)
+      Tests  248 passed (248)
+   Start at  15:17:04
+   Duration  1.36s (transform 734ms, setup 576ms, import 1.92s, tests 2.12s, environment 2.70s)
+
+```
+
+## Exercised against a synthetic 121k-item library
+
+Unit tests prove the contract; this runs the real `groupByTimestamp` and
+`splitOversizedBuckets` (bundled with esbuild) over a library shaped like a real
+one: 40,000 sparse photos plus three dense bursts of 8k / 20k / 50k that each
+land inside a single 1-hour bucket, plus 3,000 items with no timestamp.
+
+Times are derived from the measured worker rate of 6.26e8 multiply-adds/sec at
+dim=1024, not wall-clock — running the actual comparisons would take the 40
+minutes the fix exists to avoid. The harness is throwaway and lives outside the
+repo, so this block will not reproduce on a later `showboat verify`.
+
+```bash
+node /private/tmp/claude-501/-Users-yakovv-marina-work-deduper/41396d94-0894-44a5-90dd-b4886ea0e177/scratchpad/exercise/out.cjs
+```
+
+```output
+library: 121000 items (3,000 with undefined timestamps)
+
+BEFORE cap:
+  buckets: 3334, largest three: 50012, 20012, 8012
+  worst single bucket: 34.1 min
+  total pairwise time: 40.4 min
+
+AFTER cap (MAX_BUCKET_SIZE=5000):
+  buckets: 3349, largest three: 4547, 4547, 4547
+  bucketsSplit reported: 3
+  worst single bucket: 16.9 s
+  total pairwise time: 4.63 min
+
+items preserved:       118000 -> 118000  OK
+max bucket <= cap:     OK
+bad timestamps dropped: OK
+```
+
+## Result
+
+| | before | after |
+|---|---|---|
+| worst single bucket | 34.1 min | 16.9 s |
+| total pairwise time | 40.4 min | 4.63 min |
+| buckets split | — | 3 (surfaced in UI) |
+
+No items lost, no bucket above the cap, and the 3,000 timestamp-less items are
+excluded from bucketing instead of collapsing into one 3,000-item bucket.
+
+## Known limitation
+
+Duplicates that straddle a chunk boundary are not detected. That is the trade
+this change makes deliberately, and the results page now says so whenever
+`bucketsSplit > 0`. The full-mode `topK` problem (a separate O(n^2 log n) bug in
+`workerCommunityDetection`) is untouched here.

--- a/scripts/google-photos-commands.js
+++ b/scripts/google-photos-commands.js
@@ -34,14 +34,16 @@ function postError(command, requestId, error) {
 }
 
 // command is optional; when provided, the app can route progress to the right handler.
-function postProgress(requestId, itemsProcessed, message, command) {
+// extra carries optional fields such as the fetch position dates.
+function postProgress(requestId, itemsProcessed, message, command, extra) {
   window.postMessage({
     app: GPD_APP_ID,
     action: "gptkProgress",
     requestId,
     itemsProcessed,
     message,
-    ...(command !== undefined ? { command } : {})
+    ...(command !== undefined ? { command } : {}),
+    ...(extra || {})
   })
 }
 
@@ -142,10 +144,25 @@ async function getAllMediaItems(requestId, args) {
       }
       nextPageId = page.nextPageId || null
 
+      // Report how far back the fetch has reached. Items arrive newest-first by
+      // upload date, so the last item of the page is the oldest seen so far.
+      // Only finite, non-zero values are sent — some items carry no usable date
+      // and would otherwise render as 1 Jan 1970.
+      const oldest = mediaItems[mediaItems.length - 1]
+      const position = {}
+      if (oldest) {
+        if (Number.isFinite(oldest.creationTimestamp) && oldest.creationTimestamp > 0)
+          position.oldestUploadedAt = oldest.creationTimestamp
+        if (Number.isFinite(oldest.timestamp) && oldest.timestamp > 0)
+          position.oldestTakenAt = oldest.timestamp
+      }
+
       postProgress(
         requestId,
         mediaItems.length,
-        `Fetched ${mediaItems.length} items`
+        `Fetched ${mediaItems.length} items`,
+        undefined,
+        position
       )
 
       if (reachedCache) break

--- a/scripts/google-photos-commands.js
+++ b/scripts/google-photos-commands.js
@@ -137,6 +137,9 @@ async function getAllMediaItems(requestId, args) {
             duration: item.duration,
             isOwned: item.isOwned,
             isOriginalQuality: item.isOriginalQuality ?? null,
+            // GPTK omits this rather than sending false; normalise to a boolean
+            // so downstream keep-selection can test it plainly.
+            isFavorite: item.isFavorite === true,
             fileName: item.descriptionShort || null,
             productUrl: "https://photos.google.com" + accountUrlPrefix + "photo/" + item.mediaKey
           })

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -337,7 +337,9 @@ export default function App() {
           })
         }
 
-        const groups =
+        // Smart mode reports how many timestamp buckets it had to split to
+        // keep pairwise comparison bounded; full mode never splits.
+        const { groups, bucketsSplit } =
           settingsRef.current.scanMode === "smart"
             ? await smartDetectDuplicates(
                 items,
@@ -355,7 +357,7 @@ export default function App() {
                   signal,
                   logger
                 )
-                return result.groups
+                return { groups: result.groups, bucketsSplit: 0 }
               })()
 
         await logger.finalize("complete", { groupsFound: groups.length })
@@ -369,7 +371,8 @@ export default function App() {
         dispatch({
           type: "SCAN_COMPLETE",
           mediaItems: mediaItemMap,
-          groups
+          groups,
+          bucketsSplit
         })
         // Refresh account email after scan — the email in state may be stale
         // if the user switched accounts since the last health check.
@@ -421,6 +424,7 @@ export default function App() {
             mediaItems: result.scanResults.mediaItems,
             groups: result.scanResults.groups,
             totalItems: result.scanResults.totalItems,
+            bucketsSplit: result.scanResults.bucketsSplit,
             accountEmail: result.scanResults.accountEmail
           })
         }
@@ -483,6 +487,10 @@ export default function App() {
   )
   const totalItems = state.status === "results" ? state.totalItems : 0
   const accountEmailForStorage = state.status === "results" ? state.accountEmail : undefined
+  const bucketsSplit =
+    state.status === "results" || state.status === "trashing"
+      ? state.bucketsSplit
+      : 0
   useEffect(() => {
     if (!mediaItems) return
     if (groups.length > 0) {
@@ -497,6 +505,7 @@ export default function App() {
           scanDate: Date.now(),
           totalItems,
           newestCreationTimestamp,
+          bucketsSplit,
           accountEmail: accountEmailForStorage
         }
       })
@@ -504,7 +513,7 @@ export default function App() {
       // All duplicates removed — clear saved results so next open starts fresh
       chrome.storage.local.remove("scanResults")
     }
-  }, [groups, mediaItems, totalItems, accountEmailForStorage])
+  }, [groups, mediaItems, totalItems, bucketsSplit, accountEmailForStorage])
 
   // Persist selections when they change (only while results are showing)
   useEffect(() => {
@@ -812,6 +821,7 @@ export default function App() {
               onToggleGroup={handleToggleGroup}
               keptByGroupId={keptByGroupId}
               onToggleKept={handleToggleKept}
+              bucketsSplit={state.bucketsSplit}
             />
           </>
         )}

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -782,6 +782,8 @@ export default function App() {
             totalEstimate={state.totalEstimate}
             message={state.message}
             onCancel={handleCancelScan}
+            oldestUploadedAt={state.oldestUploadedAt}
+            oldestTakenAt={state.oldestTakenAt}
           />
         )}
 

--- a/tabs/app.tsx
+++ b/tabs/app.tsx
@@ -36,6 +36,10 @@ import { ScanLogger } from "../lib/scan-log"
 import theme from "../lib/theme"
 import { APP_ID, DEFAULT_SETTINGS } from "../lib/types"
 import { areScanResultsValid } from "../lib/scan-results"
+import {
+  countFullyTrashedGroups,
+  toggleWholeGroupTrashed
+} from "../lib/kept-overrides"
 import type {
   AppMessage,
   DuplicateGroup,
@@ -91,6 +95,7 @@ export default function App() {
   const [trashConfirm, setTrashConfirm] = useState<{
     dedupKeys: string[]
     mediaKeysToTrash: string[]
+    fullyTrashedGroups: number
   } | null>(null)
 
   // Undo trash state: stored after a successful trash operation
@@ -485,6 +490,14 @@ export default function App() {
     },
     [defaultKeptSets]
   )
+
+  // Trash an entire group. This is the only path that leaves a group with no
+  // survivor — the per-photo toggle above still refuses to remove the last
+  // kept item, so a group can only be emptied deliberately.
+  const handleTrashWholeGroup = useCallback((group: DuplicateGroup) => {
+    setKeptOverrides((prev) => toggleWholeGroupTrashed(prev, group.id))
+  }, [])
+
   const totalItems = state.status === "results" ? state.totalItems : 0
   const accountEmailForStorage = state.status === "results" ? state.accountEmail : undefined
   const bucketsSplit =
@@ -617,7 +630,12 @@ export default function App() {
     }
 
     if (dedupKeys.length === 0) return
-    setTrashConfirm({ dedupKeys, mediaKeysToTrash })
+    const fullyTrashedGroups = countFullyTrashedGroups(
+      state.groups,
+      selectedGroupIds,
+      getKept
+    )
+    setTrashConfirm({ dedupKeys, mediaKeysToTrash, fullyTrashedGroups })
   }, [state, selectedGroupIds, getKept])
 
   const handleTrashConfirmed = useCallback(() => {
@@ -823,6 +841,7 @@ export default function App() {
               onToggleGroup={handleToggleGroup}
               keptByGroupId={keptByGroupId}
               onToggleKept={handleToggleKept}
+              onTrashWholeGroup={handleTrashWholeGroup}
               bucketsSplit={state.bucketsSplit}
             />
           </>
@@ -858,6 +877,13 @@ export default function App() {
             {trashConfirm?.dedupKeys.length !== 1 ? "s" : ""} to trash? You can
             restore them from the Google Photos trash.
           </DialogContentText>
+          {!!trashConfirm?.fullyTrashedGroups && (
+            <DialogContentText sx={{ mt: 2 }} color="error">
+              {trashConfirm.fullyTrashedGroups} group
+              {trashConfirm.fullyTrashedGroups !== 1 ? "s" : ""} will be removed
+              entirely — no copy will be kept.
+            </DialogContentText>
+          )}
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setTrashConfirm(null)}>Cancel</Button>

--- a/tests/commands/google-photos-commands.test.ts
+++ b/tests/commands/google-photos-commands.test.ts
@@ -522,3 +522,57 @@ describe("getAllMediaItems — fetch position", () => {
     expect(p.oldestTakenAt).toBeUndefined()
   })
 })
+
+// ============================================================
+// getAllMediaItems — favorite flag
+//
+// GPTK's libraryItemParse reads isFavorite from the protobuf extras map, where
+// it is absent rather than false for non-favorites. The projection normalises
+// it so keep-selection can test a plain boolean.
+// ============================================================
+
+describe("getAllMediaItems — favorite flag", () => {
+  function setupGptkApi(items: unknown[], nextPageId: string | null = null) {
+    ;(window as any).gptkApi = {
+      getItemsByUploadedDate: vi.fn().mockResolvedValue({ items, nextPageId }),
+    }
+  }
+
+  afterEach(() => {
+    delete (window as any).gptkApi
+    window.history.pushState({}, "", "/")
+  })
+
+  async function firstItem(raw: Record<string, unknown>) {
+    setupGptkApi([
+      {
+        mediaKey: "mk1",
+        dedupKey: "dk1",
+        thumb: "https://thumb/1",
+        timestamp: 1,
+        creationTimestamp: 2,
+        ...raw,
+      },
+    ])
+    const { messages, restore } = collectMessages()
+    sendCommand("getAllMediaItems", `req-fav-${Math.random()}`, {})
+    await flush()
+    const result = messages.find(
+      (m: any) => m.action === "gptkResult" && m.command === "getAllMediaItems"
+    ) as any
+    restore()
+    return result?.data?.[0]
+  }
+
+  it("passes isFavorite=true through to the output item", async () => {
+    expect((await firstItem({ isFavorite: true })).isFavorite).toBe(true)
+  })
+
+  it("normalises an absent isFavorite to false", async () => {
+    expect((await firstItem({})).isFavorite).toBe(false)
+  })
+
+  it("normalises an explicit false to false", async () => {
+    expect((await firstItem({ isFavorite: false })).isFavorite).toBe(false)
+  })
+})

--- a/tests/commands/google-photos-commands.test.ts
+++ b/tests/commands/google-photos-commands.test.ts
@@ -451,3 +451,74 @@ describe("getAllMediaItems — page timeout", () => {
     restore()
   })
 })
+
+// ============================================================
+// getAllMediaItems — fetch position reporting
+//
+// Progress messages carry the oldest item seen so far so the UI can show how
+// far back through the library the fetch has walked.
+// ============================================================
+
+describe("getAllMediaItems — fetch position", () => {
+  function setupGptkApi(items: unknown[], nextPageId: string | null = null) {
+    ;(window as any).gptkApi = {
+      getItemsByUploadedDate: vi.fn().mockResolvedValue({ items, nextPageId }),
+    }
+  }
+
+  afterEach(() => {
+    delete (window as any).gptkApi
+    window.history.pushState({}, "", "/")
+  })
+
+  const item = (mediaKey: string, timestamp: number, creationTimestamp: number) => ({
+    mediaKey,
+    dedupKey: `dk-${mediaKey}`,
+    thumb: `https://thumb/${mediaKey}`,
+    timestamp,
+    creationTimestamp,
+  })
+
+  async function progressFor(items: unknown[]) {
+    setupGptkApi(items)
+    const { messages, restore } = collectMessages()
+    sendCommand("getAllMediaItems", `req-pos-${Math.random()}`, {})
+    await flush()
+    const progress = messages.filter((m: any) => m.action === "gptkProgress")
+    restore()
+    return progress[progress.length - 1] as any
+  }
+
+  it("reports the oldest item's upload and taken dates", async () => {
+    const p = await progressFor([
+      item("mk1", 1000, 5000),
+      item("mk2", 900, 4000), // last item = oldest, since pages are newest-first
+    ])
+    expect(p.oldestUploadedAt).toBe(4000)
+    expect(p.oldestTakenAt).toBe(900)
+  })
+
+  // Real libraries contain items with no usable date; these must not be sent,
+  // or the UI would render them as 1 Jan 1970.
+  it("omits a zero upload date", async () => {
+    const p = await progressFor([item("mk1", 1000, 5000), item("mk2", 900, 0)])
+    expect(p.oldestUploadedAt).toBeUndefined()
+    expect(p.oldestTakenAt).toBe(900)
+  })
+
+  it("omits a missing taken date", async () => {
+    const p = await progressFor([
+      item("mk1", 1000, 5000),
+      { ...item("mk2", 0, 4000), timestamp: undefined },
+    ])
+    expect(p.oldestUploadedAt).toBe(4000)
+    expect(p.oldestTakenAt).toBeUndefined()
+  })
+
+  it("still reports the item count when no dates are usable", async () => {
+    const p = await progressFor([item("mk1", 0, 0)])
+    expect(p.itemsProcessed).toBe(1)
+    expect(p.oldestUploadedAt).toBeUndefined()
+    expect(p.oldestTakenAt).toBeUndefined()
+  })
+})

--- a/tests/components/duplicate-groups.test.tsx
+++ b/tests/components/duplicate-groups.test.tsx
@@ -75,6 +75,7 @@ const defaultProps = {
   onToggleGroup: vi.fn(),
   keptByGroupId: new Map([["g1", new Set(["img1"])]]),
   onToggleKept: vi.fn(),
+  onTrashWholeGroup: vi.fn(),
 }
 
 // ============================================================
@@ -379,6 +380,83 @@ describe("favorite badge", () => {
     expect(screen.getByTestId("favorite-badge-a")).toHaveAttribute(
       "title",
       expect.stringMatching(/favorite/i)
+    )
+  })
+})
+
+// Trash whole group
+//
+// The one action that leaves a group with no survivor, so it has to be
+// deliberate and clearly signposted.
+// ============================================================
+
+describe("trash whole group", () => {
+  it("renders a trash-all control for each group", () => {
+    wrap(<DuplicateGroups {...defaultProps} />)
+    expect(screen.getByTestId("trash-whole-group-g1")).toBeInTheDocument()
+  })
+
+  it("calls onTrashWholeGroup with the group when clicked", () => {
+    const onTrashWholeGroup = vi.fn()
+    wrap(<DuplicateGroups {...defaultProps} onTrashWholeGroup={onTrashWholeGroup} />)
+    fireEvent.click(screen.getByTestId("trash-whole-group-g1"))
+    expect(onTrashWholeGroup).toHaveBeenCalledTimes(1)
+    expect(onTrashWholeGroup.mock.calls[0][0].id).toBe("g1")
+  })
+
+  // The group header itself toggles selection, so the control must not
+  // bubble — otherwise trashing a group would also deselect it.
+  it("does not toggle group selection when clicked", () => {
+    const onToggleGroup = vi.fn()
+    wrap(
+      <DuplicateGroups
+        {...defaultProps}
+        onToggleGroup={onToggleGroup}
+        onTrashWholeGroup={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByTestId("trash-whole-group-g1"))
+    expect(onToggleGroup).not.toHaveBeenCalled()
+  })
+
+  it("shows no Keep chip when the group keeps nothing", () => {
+    wrap(
+      <DuplicateGroups
+        {...defaultProps}
+        keptByGroupId={new Map([["g1", new Set<string>()]])}
+      />
+    )
+    expect(screen.queryByText("Keep")).not.toBeInTheDocument()
+  })
+
+  it("marks every item for trash when the group keeps nothing", () => {
+    wrap(
+      <DuplicateGroups
+        {...defaultProps}
+        keptByGroupId={new Map([["g1", new Set<string>()]])}
+      />
+    )
+    expect(screen.getAllByText("Trash")).toHaveLength(group.mediaKeys.length)
+  })
+
+  it("labels the control as active while the group is fully trashed", () => {
+    wrap(
+      <DuplicateGroups
+        {...defaultProps}
+        keptByGroupId={new Map([["g1", new Set<string>()]])}
+      />
+    )
+    expect(screen.getByTestId("trash-whole-group-g1")).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    )
+  })
+
+  it("is not active while the group still keeps an item", () => {
+    wrap(<DuplicateGroups {...defaultProps} />)
+    expect(screen.getByTestId("trash-whole-group-g1")).toHaveAttribute(
+      "aria-pressed",
+      "false"
     )
   })
 })

--- a/tests/components/duplicate-groups.test.tsx
+++ b/tests/components/duplicate-groups.test.tsx
@@ -281,3 +281,35 @@ describe("DuplicateGroups — Spacebar preview", () => {
     expect(screen.queryByTestId("viewer-modal")).not.toBeInTheDocument()
   })
 })
+
+// ============================================================
+// Split-bucket caveat
+// ============================================================
+
+describe("split bucket notice", () => {
+  it("warns when timestamp buckets were split", () => {
+    wrap(<DuplicateGroups {...defaultProps} bucketsSplit={3} />)
+    const notice = screen.getByTestId("split-buckets-notice")
+    expect(notice).toBeInTheDocument()
+    expect(notice).toHaveTextContent(/3 large time groups/i)
+    expect(notice).toHaveTextContent(/may be missed/i)
+  })
+
+  it("uses singular wording for a single split group", () => {
+    wrap(<DuplicateGroups {...defaultProps} bucketsSplit={1} />)
+    expect(screen.getByTestId("split-buckets-notice")).toHaveTextContent(
+      /1 large time group was split/i
+    )
+  })
+
+  it("shows nothing when no buckets were split", () => {
+    wrap(<DuplicateGroups {...defaultProps} bucketsSplit={0} />)
+    expect(screen.queryByTestId("split-buckets-notice")).not.toBeInTheDocument()
+  })
+
+  // Results saved before this field existed load without it.
+  it("shows nothing when bucketsSplit is absent", () => {
+    wrap(<DuplicateGroups {...defaultProps} />)
+    expect(screen.queryByTestId("split-buckets-notice")).not.toBeInTheDocument()
+  })
+})

--- a/tests/components/duplicate-groups.test.tsx
+++ b/tests/components/duplicate-groups.test.tsx
@@ -313,3 +313,72 @@ describe("split bucket notice", () => {
     expect(screen.queryByTestId("split-buckets-notice")).not.toBeInTheDocument()
   })
 })
+
+// ============================================================
+// Favorite badge
+//
+// Favorites win the default keep, so the star is what explains why a
+// particular photo was chosen.
+// ============================================================
+
+describe("favorite badge", () => {
+  const favorite = (k: string): GpdMediaItem => ({ ...makeItem(k), isFavorite: true })
+
+  function renderWith(items: Record<string, GpdMediaItem>, keys: string[]) {
+    wrap(
+      <DuplicateGroups
+        {...defaultProps}
+        groups={[makeGroup("gf", ...keys)]}
+        mediaItems={items}
+        selectedGroupIds={new Set(["gf"])}
+        keptByGroupId={new Map([["gf", new Set([keys[0]])]])}
+      />
+    )
+  }
+
+  it("marks a favorited photo with a star", () => {
+    renderWith({ a: favorite("a"), b: makeItem("b") }, ["a", "b"])
+    expect(screen.getByTestId("favorite-badge-a")).toBeInTheDocument()
+  })
+
+  it("does not mark a non-favorited photo", () => {
+    renderWith({ a: favorite("a"), b: makeItem("b") }, ["a", "b"])
+    expect(screen.queryByTestId("favorite-badge-b")).not.toBeInTheDocument()
+  })
+
+  // Google omits the field rather than sending false.
+  it("does not mark a photo whose isFavorite is absent", () => {
+    renderWith({ a: makeItem("a"), b: makeItem("b") }, ["a", "b"])
+    expect(screen.queryByTestId("favorite-badge-a")).not.toBeInTheDocument()
+  })
+
+  it("marks every favorited photo in a group", () => {
+    renderWith(
+      { a: favorite("a"), b: makeItem("b"), c: favorite("c") },
+      ["a", "b", "c"]
+    )
+    expect(screen.getByTestId("favorite-badge-a")).toBeInTheDocument()
+    expect(screen.getByTestId("favorite-badge-c")).toBeInTheDocument()
+    expect(screen.queryByTestId("favorite-badge-b")).not.toBeInTheDocument()
+  })
+
+  it("marks a favorite regardless of whether it is the kept photo", () => {
+    renderWith({ a: makeItem("a"), b: favorite("b") }, ["a", "b"])
+    expect(screen.getByTestId("favorite-badge-b")).toBeInTheDocument()
+  })
+
+  // It reports Google Photos state we cannot change from here, so it must not
+  // be a control — and must not steal the card's keep/trash click.
+  it("is not a button", () => {
+    renderWith({ a: favorite("a") }, ["a"])
+    expect(screen.getByTestId("favorite-badge-a").tagName).not.toBe("BUTTON")
+  })
+
+  it("explains itself on hover", () => {
+    renderWith({ a: favorite("a") }, ["a"])
+    expect(screen.getByTestId("favorite-badge-a")).toHaveAttribute(
+      "title",
+      expect.stringMatching(/favorite/i)
+    )
+  })
+})

--- a/tests/components/photo-viewer-modal.test.tsx
+++ b/tests/components/photo-viewer-modal.test.tsx
@@ -437,3 +437,37 @@ describe("PhotoViewerModal — fetching and prefetching", () => {
     )
   })
 })
+
+// ============================================================
+// Favorite badge
+//
+// The grid marks favorites; the viewer is where the photo is actually
+// inspected, so the marker has to survive opening it.
+// ============================================================
+
+describe("PhotoViewerModal — favorite badge", () => {
+  it("marks a favorited photo", () => {
+    wrap(
+      <PhotoViewerModal {...defaultProps} items={[makeItem("f1", { isFavorite: true })]} />
+    )
+    expect(screen.getByTestId("viewer-favorite-badge")).toBeInTheDocument()
+  })
+
+  it("does not mark a non-favorited photo", () => {
+    wrap(<PhotoViewerModal {...defaultProps} items={[makeItem("n1")]} />)
+    expect(screen.queryByTestId("viewer-favorite-badge")).not.toBeInTheDocument()
+  })
+
+  it("follows navigation between a favorite and a non-favorite", () => {
+    wrap(
+      <PhotoViewerModal
+        {...defaultProps}
+        items={[makeItem("f1", { isFavorite: true }), makeItem("n1")]}
+        initialIndex={0}
+      />
+    )
+    expect(screen.getByTestId("viewer-favorite-badge")).toBeInTheDocument()
+    fireEvent.keyDown(window, { key: "ArrowRight" })
+    expect(screen.queryByTestId("viewer-favorite-badge")).not.toBeInTheDocument()
+  })
+})

--- a/tests/components/scan-config.test.tsx
+++ b/tests/components/scan-config.test.tsx
@@ -96,3 +96,43 @@ describe("ScanConfig — time window toggle", () => {
     expect(screen.queryByText(/Time window:/)).not.toBeInTheDocument()
   })
 })
+
+// ============================================================
+// Similarity threshold range
+//
+// The slider used to stop at 0.90, which put looser matching out of reach
+// entirely. Lowering the floor to 0.75 makes it reachable; the default is
+// unchanged, so nobody gets looser matching without asking for it.
+// ============================================================
+
+describe("ScanConfig — similarity threshold range", () => {
+  const slider = () => document.querySelector('input[type="range"]')!
+
+  it("allows the threshold to go down to 0.75", () => {
+    renderConfig()
+    expect(slider()).toHaveAttribute("min", "0.75")
+  })
+
+  it("still tops out at exact matching", () => {
+    renderConfig()
+    expect(slider()).toHaveAttribute("max", "1")
+  })
+
+  it("keeps the 0.01 step", () => {
+    renderConfig()
+    expect(slider()).toHaveAttribute("step", "0.01")
+  })
+
+  it("renders a threshold below the old 0.90 floor", () => {
+    renderConfig({ similarityThreshold: 0.8 })
+    expect(slider()).toHaveValue("0.8")
+    // Scoped to the threshold heading — the raw value also appears in the
+    // slider's value label, and other settings have <strong> labels of their own.
+    expect(screen.getByText(/Similarity Threshold:/)).toHaveTextContent("0.8")
+  })
+
+  it("leaves the default threshold untouched", () => {
+    renderConfig()
+    expect(slider()).toHaveValue("0.99")
+  })
+})

--- a/tests/components/scan-progress.test.tsx
+++ b/tests/components/scan-progress.test.tsx
@@ -22,6 +22,8 @@ interface Props {
   totalEstimate?: number
   message?: string
   onCancel?: (() => void) | undefined
+  oldestUploadedAt?: number | undefined
+  oldestTakenAt?: number | undefined
 }
 
 function renderScanProgress(props: Props = {}) {
@@ -31,6 +33,8 @@ function renderScanProgress(props: Props = {}) {
     totalEstimate: 0,
     message: "",
     onCancel: undefined,
+    oldestUploadedAt: undefined,
+    oldestTakenAt: undefined,
   }
   const merged = { ...defaults, ...props }
   return render(
@@ -113,6 +117,72 @@ describe("ScanProgress", () => {
     it("shows 'Scanning Library' heading", () => {
       renderScanProgress()
       expect(screen.getByText("Scanning Library")).toBeInTheDocument()
+    })
+  })
+
+  // ============================================================
+  // Fetch position readout
+  //
+  // Pagination is newest-first by UPLOAD date, so the upload date walks
+  // backwards monotonically and is the honest "how far have we got" signal.
+  // The taken date is shown alongside because the two often diverge.
+  // ============================================================
+
+  describe("fetch position", () => {
+    const MAR_2023 = Date.parse("2023-03-12T10:00:00Z")
+    const JUL_2019 = Date.parse("2019-07-04T10:00:00Z")
+
+    it("shows the upload position during the fetching phase", () => {
+      renderScanProgress({ phase: "fetching", oldestUploadedAt: MAR_2023 })
+      const el = screen.getByTestId("fetch-position")
+      expect(el).toHaveTextContent(/uploads from/i)
+      expect(el).toHaveTextContent(/2023/)
+    })
+
+    it("shows the taken date alongside the upload date", () => {
+      renderScanProgress({
+        phase: "fetching",
+        oldestUploadedAt: MAR_2023,
+        oldestTakenAt: JUL_2019,
+      })
+      const el = screen.getByTestId("fetch-position")
+      expect(el).toHaveTextContent(/2023/)
+      expect(el).toHaveTextContent(/taken/i)
+      expect(el).toHaveTextContent(/2019/)
+    })
+
+    it("omits the taken date when it is absent", () => {
+      renderScanProgress({ phase: "fetching", oldestUploadedAt: MAR_2023 })
+      expect(screen.getByTestId("fetch-position")).not.toHaveTextContent(/taken/i)
+    })
+
+    it("renders nothing when no upload date has arrived yet", () => {
+      renderScanProgress({ phase: "fetching" })
+      expect(screen.queryByTestId("fetch-position")).not.toBeInTheDocument()
+    })
+
+    // Items with a 0 or non-finite timestamp exist in real libraries; they must
+    // not render as 1 Jan 1970.
+    it("renders nothing for a zero timestamp", () => {
+      renderScanProgress({ phase: "fetching", oldestUploadedAt: 0 })
+      expect(screen.queryByTestId("fetch-position")).not.toBeInTheDocument()
+    })
+
+    it("renders nothing for a non-finite timestamp", () => {
+      renderScanProgress({ phase: "fetching", oldestUploadedAt: NaN })
+      expect(screen.queryByTestId("fetch-position")).not.toBeInTheDocument()
+    })
+
+    it("is only shown while fetching, not in later phases", () => {
+      for (const phase of [
+        "downloading_thumbnails",
+        "computing_embeddings",
+        "detecting_duplicates",
+      ] as ScanPhase[]) {
+        const { unmount } = renderScanProgress({ phase, oldestUploadedAt: MAR_2023 })
+        expect(screen.queryByTestId("fetch-position")).not.toBeInTheDocument()
+        unmount()
+      }
     })
   })
 })

--- a/tests/lib/app-reducer.test.ts
+++ b/tests/lib/app-reducer.test.ts
@@ -295,3 +295,74 @@ describe("RESET", () => {
     expect(next).toEqual({ status: "connecting" })
   })
 })
+
+// ============================================================
+// bucketsSplit — the "some duplicates may be missed" caveat
+// ============================================================
+
+const scanningState: AppState = {
+  status: "scanning",
+  phase: "fetching",
+  itemsProcessed: 0,
+  totalEstimate: 0,
+  message: "",
+  requestId: "r",
+  hasGptk: true,
+}
+
+describe("bucketsSplit", () => {
+  it("carries bucketsSplit from SCAN_COMPLETE into results", () => {
+    const next = appReducer(scanningState, {
+      type: "SCAN_COMPLETE",
+      mediaItems,
+      groups,
+      bucketsSplit: 3,
+    })
+    expect(next).toMatchObject({ status: "results", bucketsSplit: 3 })
+  })
+
+  it("defaults bucketsSplit to 0 when SCAN_COMPLETE omits it", () => {
+    const next = appReducer(scanningState, {
+      type: "SCAN_COMPLETE",
+      mediaItems,
+      groups,
+    })
+    expect(next).toMatchObject({ status: "results", bucketsSplit: 0 })
+  })
+
+  it("restores bucketsSplit from saved results", () => {
+    const next = appReducer(resultsState, {
+      type: "LOAD_SAVED_RESULTS",
+      mediaItems,
+      groups,
+      totalItems: 4,
+      bucketsSplit: 2,
+    })
+    expect(next).toMatchObject({ status: "results", bucketsSplit: 2 })
+  })
+
+  // The caveat is about scan completeness, so it must survive a trash round
+  // trip — the group list is still on screen throughout.
+  it("preserves bucketsSplit through TRASH_STARTED and TRASH_COMPLETE", () => {
+    const withSplit = appReducer(scanningState, {
+      type: "SCAN_COMPLETE",
+      mediaItems,
+      groups,
+      bucketsSplit: 5,
+    })
+    const trashing = appReducer(withSplit, {
+      type: "TRASH_STARTED",
+      totalToTrash: 2,
+      mediaItems,
+      groups,
+      totalItems: 4,
+    })
+    expect(trashing).toMatchObject({ status: "trashing", bucketsSplit: 5 })
+
+    const done = appReducer(trashing, {
+      type: "TRASH_COMPLETE",
+      trashedKeys: ["img2"],
+    })
+    expect(done).toMatchObject({ status: "results", bucketsSplit: 5 })
+  })
+})

--- a/tests/lib/app-reducer.test.ts
+++ b/tests/lib/app-reducer.test.ts
@@ -366,3 +366,63 @@ describe("bucketsSplit", () => {
     expect(done).toMatchObject({ status: "results", bucketsSplit: 5 })
   })
 })
+
+// ============================================================
+// Fetch position — how far back the fetch has walked
+// ============================================================
+
+describe("SCAN_PROGRESS fetch position", () => {
+  const MAR_2023 = Date.parse("2023-03-12T10:00:00Z")
+  const JUL_2019 = Date.parse("2019-07-04T10:00:00Z")
+  const FEB_2023 = Date.parse("2023-02-01T10:00:00Z")
+
+  const progress = (extra: Record<string, unknown> = {}) => ({
+    type: "SCAN_PROGRESS" as const,
+    payload: {
+      app: APP_ID,
+      action: "gptkProgress" as const,
+      requestId: "r",
+      itemsProcessed: 100,
+      ...extra,
+    },
+  })
+
+  it("carries upload and taken dates onto the scanning state", () => {
+    const next = appReducer(
+      scanningState,
+      progress({ oldestUploadedAt: MAR_2023, oldestTakenAt: JUL_2019 })
+    )
+    expect(next).toMatchObject({
+      status: "scanning",
+      oldestUploadedAt: MAR_2023,
+      oldestTakenAt: JUL_2019,
+    })
+  })
+
+  // Progress messages arrive continuously; one without dates must not blank
+  // out a position already on screen.
+  it("preserves a known position when a later message omits the dates", () => {
+    const withPos = appReducer(
+      scanningState,
+      progress({ oldestUploadedAt: MAR_2023, oldestTakenAt: JUL_2019 })
+    )
+    const next = appReducer(withPos, progress({ itemsProcessed: 200 }))
+    expect(next).toMatchObject({
+      itemsProcessed: 200,
+      oldestUploadedAt: MAR_2023,
+      oldestTakenAt: JUL_2019,
+    })
+  })
+
+  it("advances the position as the fetch walks backwards", () => {
+    const first = appReducer(scanningState, progress({ oldestUploadedAt: MAR_2023 }))
+    const second = appReducer(first, progress({ oldestUploadedAt: FEB_2023 }))
+    expect(second).toMatchObject({ oldestUploadedAt: FEB_2023 })
+  })
+
+  it("leaves the position undefined before any dates arrive", () => {
+    const next = appReducer(scanningState, progress())
+    expect(next).toMatchObject({ status: "scanning" })
+    expect((next as { oldestUploadedAt?: number }).oldestUploadedAt).toBeUndefined()
+  })
+})

--- a/tests/lib/duplicate-detector.test.ts
+++ b/tests/lib/duplicate-detector.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { communityDetection, matMul, topK, groupByTimestamp, withinGroupDuplicates, selectDefaultKeep, fullDetectDuplicates, dedupeByDedupKey } from "../../lib/duplicate-detector"
+import { communityDetection, matMul, topK, groupByTimestamp, withinGroupDuplicates, selectDefaultKeep, fullDetectDuplicates, dedupeByDedupKey, splitOversizedBuckets, MAX_BUCKET_SIZE } from "../../lib/duplicate-detector"
 import type { GpdMediaItem } from "../../lib/types"
 
 // ============================================================
@@ -327,6 +327,140 @@ describe("groupByTimestamp", () => {
     // a floors to 0, b floors to 1000
     const result = groupByTimestamp([a, b], 1000)
     expect(result).toHaveLength(0)
+  })
+
+  // Degenerate timestamps must not collapse into a single giant bucket.
+  // Math.floor(undefined / w) is NaN, and Map treats every NaN as the same
+  // key — so without a guard every such item lands in one bucket and the
+  // pairwise comparison there is quadratic in the whole library.
+  it("excludes items with an undefined timestamp instead of bucketing them together", () => {
+    const items = [
+      makeItem("a", undefined as unknown as number),
+      makeItem("b", undefined as unknown as number),
+      makeItem("c", undefined as unknown as number),
+    ]
+    expect(groupByTimestamp(items, 1000)).toHaveLength(0)
+  })
+
+  it("excludes items with a NaN timestamp", () => {
+    const items = [makeItem("a", NaN), makeItem("b", NaN)]
+    expect(groupByTimestamp(items, 1000)).toHaveLength(0)
+  })
+
+  // null / 1000 === 0, so these would silently join the epoch bucket.
+  it("excludes items with a null timestamp instead of putting them in the epoch bucket", () => {
+    const items = [
+      makeItem("a", null as unknown as number),
+      makeItem("b", null as unknown as number),
+      makeItem("real", 0),
+    ]
+    expect(groupByTimestamp(items, 1000)).toHaveLength(0)
+  })
+
+  it("still buckets valid timestamps when degenerate ones are present", () => {
+    const items = [
+      makeItem("a", 1000),
+      makeItem("b", 1000),
+      makeItem("bad", undefined as unknown as number),
+    ]
+    const result = groupByTimestamp(items, 1000)
+    expect(result).toHaveLength(1)
+    expect(result[0].map((i) => i.mediaKey).sort()).toEqual(["a", "b"])
+  })
+})
+
+// ============================================================
+// splitOversizedBuckets
+// ============================================================
+
+describe("splitOversizedBuckets", () => {
+  /** A bucket of `n` items with strictly increasing timestamps. */
+  const bucketOf = (n: number, prefix = "i", startTs = 0) =>
+    Array.from({ length: n }, (_, k) => makeItem(`${prefix}${k}`, startTs + k))
+
+  it("leaves a bucket at the cap untouched", () => {
+    const bucket = bucketOf(10)
+    const result = splitOversizedBuckets([bucket], 10)
+    expect(result.buckets).toHaveLength(1)
+    expect(result.buckets[0]).toEqual(bucket)
+    expect(result.bucketsSplit).toBe(0)
+  })
+
+  it("leaves a bucket under the cap untouched", () => {
+    const result = splitOversizedBuckets([bucketOf(3)], 10)
+    expect(result.buckets).toHaveLength(1)
+    expect(result.bucketsSplit).toBe(0)
+  })
+
+  it("splits an oversized bucket into ceil(length / cap) chunks", () => {
+    const result = splitOversizedBuckets([bucketOf(25)], 10)
+    expect(result.buckets).toHaveLength(3) // ceil(25/10)
+    expect(result.bucketsSplit).toBe(1)
+  })
+
+  // A fixed-size split would make 5000 + 1; near-equal makes 2500 + 2501.
+  it("splits into near-equal chunks rather than cap-sized ones", () => {
+    const result = splitOversizedBuckets([bucketOf(11)], 10)
+    expect(result.buckets).toHaveLength(2)
+    const sizes = result.buckets.map((b) => b.length).sort((a, b) => a - b)
+    expect(sizes[1] - sizes[0]).toBeLessThanOrEqual(1)
+  })
+
+  it("never produces a chunk larger than the cap", () => {
+    const result = splitOversizedBuckets([bucketOf(97)], 10)
+    for (const b of result.buckets) expect(b.length).toBeLessThanOrEqual(10)
+  })
+
+  it("loses no items when splitting", () => {
+    const bucket = bucketOf(25)
+    const result = splitOversizedBuckets([bucket], 10)
+    const keys = result.buckets.flat().map((i) => i.mediaKey).sort()
+    expect(keys).toEqual(bucket.map((i) => i.mediaKey).sort())
+  })
+
+  it("produces time-contiguous chunks even when input is unordered", () => {
+    // Shuffled timestamps — chunks must still be contiguous in time so that
+    // near-in-time duplicates stay in the same chunk.
+    const bucket = [
+      makeItem("e", 50),
+      makeItem("a", 10),
+      makeItem("d", 40),
+      makeItem("b", 20),
+      makeItem("c", 30),
+      makeItem("f", 60),
+    ]
+    const result = splitOversizedBuckets([bucket], 3)
+    expect(result.buckets).toHaveLength(2)
+    expect(result.buckets[0].map((i) => i.mediaKey)).toEqual(["a", "b", "c"])
+    expect(result.buckets[1].map((i) => i.mediaKey)).toEqual(["d", "e", "f"])
+  })
+
+  it("counts split source buckets, not resulting chunks", () => {
+    const result = splitOversizedBuckets([bucketOf(25, "x"), bucketOf(30, "y")], 10)
+    // 3 chunks + 3 chunks = 6 buckets out, but only 2 were split
+    expect(result.buckets).toHaveLength(6)
+    expect(result.bucketsSplit).toBe(2)
+  })
+
+  it("splits only the oversized buckets in a mixed set", () => {
+    const small = bucketOf(2, "s")
+    const big = bucketOf(25, "b")
+    const result = splitOversizedBuckets([small, big], 10)
+    expect(result.bucketsSplit).toBe(1)
+    expect(result.buckets).toContainEqual(small)
+    expect(result.buckets).toHaveLength(4) // 1 small + 3 chunks
+  })
+
+  it("handles an empty bucket list", () => {
+    const result = splitOversizedBuckets([], 10)
+    expect(result.buckets).toEqual([])
+    expect(result.bucketsSplit).toBe(0)
+  })
+
+  it("defaults to MAX_BUCKET_SIZE when no cap is given", () => {
+    const result = splitOversizedBuckets([bucketOf(MAX_BUCKET_SIZE + 1)])
+    expect(result.bucketsSplit).toBe(1)
+    expect(result.buckets).toHaveLength(2)
   })
 })
 

--- a/tests/lib/duplicate-detector.test.ts
+++ b/tests/lib/duplicate-detector.test.ts
@@ -601,6 +601,7 @@ describe("selectDefaultKeep", () => {
       resWidth?: number
       resHeight?: number
       creationTimestamp?: number
+      isFavorite?: boolean
     } = {},
   ): GpdMediaItem {
     return {
@@ -612,6 +613,7 @@ describe("selectDefaultKeep", () => {
       resWidth: opts.resWidth,
       resHeight: opts.resHeight,
       isOriginalQuality: opts.isOriginalQuality,
+      isFavorite: opts.isFavorite,
     }
   }
 
@@ -667,6 +669,57 @@ describe("selectDefaultKeep", () => {
     const b = item("b", { isOriginalQuality: true, resWidth: 1920, resHeight: 1080, creationTimestamp: 0 })
     const result = selectDefaultKeep([a, b])
     expect(["a", "b"]).toContain(result)
+  })
+
+  // Favorites outrank every quality heuristic: the user marked that photo
+  // deliberately, and trashing a favorite is the worst outcome available.
+  describe("favorites", () => {
+    it("prefers a favorite over a higher-quality non-favorite", () => {
+      const better = item("better", { isOriginalQuality: true, resWidth: 4000, resHeight: 3000 })
+      const fav = item("fav", { isOriginalQuality: false, resWidth: 100, resHeight: 100, isFavorite: true })
+      expect(selectDefaultKeep([better, fav])).toBe("fav")
+    })
+
+    it("prefers a favorite over a higher-resolution non-favorite", () => {
+      const large = item("large", { resWidth: 4000, resHeight: 3000 })
+      const fav = item("fav", { resWidth: 100, resHeight: 100, isFavorite: true })
+      expect(selectDefaultKeep([large, fav])).toBe("fav")
+    })
+
+    it("falls through to quality when both are favorites", () => {
+      const saver = item("saver", { isOriginalQuality: false, isFavorite: true })
+      const original = item("original", { isOriginalQuality: true, isFavorite: true })
+      expect(selectDefaultKeep([saver, original])).toBe("original")
+    })
+
+    it("falls through to resolution when both are favorites of equal quality", () => {
+      const small = item("small", { isOriginalQuality: true, resWidth: 800, resHeight: 600, isFavorite: true })
+      const large = item("large", { isOriginalQuality: true, resWidth: 3000, resHeight: 2000, isFavorite: true })
+      expect(selectDefaultKeep([small, large])).toBe("large")
+    })
+
+    // Google omits the field rather than sending false, so absent must not be
+    // confused with favorited.
+    it("treats an undefined isFavorite as not favorited", () => {
+      const better = item("better", { isOriginalQuality: true, resWidth: 4000, resHeight: 3000 })
+      const other = item("other", { isOriginalQuality: false, resWidth: 100, resHeight: 100 })
+      expect(selectDefaultKeep([better, other])).toBe("better")
+    })
+
+    it("treats an explicit false the same as absent", () => {
+      const better = item("better", { isOriginalQuality: true, resWidth: 4000, resHeight: 3000, isFavorite: false })
+      const worse = item("worse", { isOriginalQuality: false, resWidth: 100, resHeight: 100, isFavorite: false })
+      expect(selectDefaultKeep([better, worse])).toBe("better")
+    })
+
+    it("keeps the single favorite among several non-favorites", () => {
+      const items = [
+        item("a", { isOriginalQuality: true, resWidth: 4000, resHeight: 3000 }),
+        item("fav", { isOriginalQuality: false, resWidth: 200, resHeight: 200, isFavorite: true }),
+        item("c", { isOriginalQuality: true, resWidth: 5000, resHeight: 4000 }),
+      ]
+      expect(selectDefaultKeep(items)).toBe("fav")
+    })
   })
 })
 

--- a/tests/lib/kept-overrides.test.ts
+++ b/tests/lib/kept-overrides.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for lib/kept-overrides.ts
+ *
+ * Trashing an entire group is the one action that leaves no survivor, so the
+ * logic deciding when that happens lives in a pure module rather than inside
+ * the component tree.
+ */
+import { describe, it, expect } from "vitest"
+import {
+  isWholeGroupTrashed,
+  toggleWholeGroupTrashed,
+  countFullyTrashedGroups,
+} from "../../lib/kept-overrides"
+import type { DuplicateGroup } from "../../lib/types"
+
+const group = (id: string, ...mediaKeys: string[]): DuplicateGroup => ({
+  id,
+  mediaKeys,
+  originalMediaKey: mediaKeys[0],
+  similarity: 0.99,
+})
+
+describe("isWholeGroupTrashed", () => {
+  it("is true for an explicit empty kept set", () => {
+    expect(isWholeGroupTrashed(new Set())).toBe(true)
+  })
+
+  it("is false when something is kept", () => {
+    expect(isWholeGroupTrashed(new Set(["a"]))).toBe(false)
+  })
+
+  // No override means the default keep applies, which always keeps one.
+  it("is false when there is no override at all", () => {
+    expect(isWholeGroupTrashed(undefined)).toBe(false)
+  })
+})
+
+describe("toggleWholeGroupTrashed", () => {
+  it("marks an untouched group as fully trashed", () => {
+    const next = toggleWholeGroupTrashed({}, "g1")
+    expect(next.g1).toEqual(new Set())
+  })
+
+  it("clears a group that had a partial override", () => {
+    const next = toggleWholeGroupTrashed({ g1: new Set(["a", "b"]) }, "g1")
+    expect(next.g1).toEqual(new Set())
+  })
+
+  // Toggling back removes the override entirely so the default keep — which
+  // now prefers favorites — applies again, rather than freezing a stale choice.
+  it("restores the default by removing the override on the second toggle", () => {
+    const trashed = toggleWholeGroupTrashed({}, "g1")
+    const restored = toggleWholeGroupTrashed(trashed, "g1")
+    expect("g1" in restored).toBe(false)
+  })
+
+  it("leaves other groups untouched", () => {
+    const next = toggleWholeGroupTrashed({ g2: new Set(["x"]) }, "g1")
+    expect(next.g2).toEqual(new Set(["x"]))
+  })
+
+  it("does not mutate the input", () => {
+    const before = { g1: new Set(["a"]) }
+    toggleWholeGroupTrashed(before, "g1")
+    expect(before.g1).toEqual(new Set(["a"]))
+  })
+})
+
+describe("countFullyTrashedGroups", () => {
+  const groups = [group("g1", "a", "b"), group("g2", "c", "d"), group("g3", "e", "f")]
+
+  it("counts selected groups with an empty kept set", () => {
+    const kept = new Map([["g1", new Set<string>()], ["g2", new Set(["c"])], ["g3", new Set<string>()]])
+    const n = countFullyTrashedGroups(groups, new Set(["g1", "g2", "g3"]), (g) => kept.get(g.id)!)
+    expect(n).toBe(2)
+  })
+
+  it("ignores groups that are not selected for trashing", () => {
+    const kept = new Map([["g1", new Set<string>()], ["g2", new Set<string>()], ["g3", new Set(["e"])]])
+    const n = countFullyTrashedGroups(groups, new Set(["g3"]), (g) => kept.get(g.id)!)
+    expect(n).toBe(0)
+  })
+
+  it("returns zero when every group keeps something", () => {
+    const kept = new Map([["g1", new Set(["a"])], ["g2", new Set(["c"])], ["g3", new Set(["e"])]])
+    const n = countFullyTrashedGroups(groups, new Set(["g1", "g2", "g3"]), (g) => kept.get(g.id)!)
+    expect(n).toBe(0)
+  })
+})

--- a/tests/perf/duplicate-groups.bench.tsx
+++ b/tests/perf/duplicate-groups.bench.tsx
@@ -54,6 +54,7 @@ describe("DuplicateGroups perf", () => {
         onToggleGroup: () => {},
         keptByGroupId,
         onToggleKept: () => {},
+        onTrashWholeGroup: () => {},
       })
       unmount()
     },
@@ -70,6 +71,7 @@ describe("DuplicateGroups perf", () => {
         onToggleGroup: () => {},
         keptByGroupId,
         onToggleKept: () => {},
+        onTrashWholeGroup: () => {},
       })
       rerender(
         <ThemeProvider theme={theme}>
@@ -80,6 +82,7 @@ describe("DuplicateGroups perf", () => {
             onToggleGroup={() => {}}
             keptByGroupId={keptByGroupId}
             onToggleKept={() => {}}
+            onTrashWholeGroup={() => {}}
           />
         </ThemeProvider>
       )
@@ -98,6 +101,7 @@ describe("DuplicateGroups perf", () => {
         onToggleGroup: () => {},
         keptByGroupId,
         onToggleKept: () => {},
+        onTrashWholeGroup: () => {},
       })
       rerender(
         <ThemeProvider theme={theme}>
@@ -108,6 +112,7 @@ describe("DuplicateGroups perf", () => {
             onToggleGroup={() => {}}
             keptByGroupId={keptBigGroupToggled}
             onToggleKept={() => {}}
+            onTrashWholeGroup={() => {}}
           />
         </ThemeProvider>
       )

--- a/workers/embedder.worker.ts
+++ b/workers/embedder.worker.ts
@@ -159,8 +159,11 @@ self.addEventListener("message", async (event: MessageEvent) => {
       for (const [, members] of components)
         if (members.length >= 2) allGroups.push(members);
 
-      if (bi % 100 === 0)
-        self.postMessage({ type: "detectionProgress", current: bi + 1, total: buckets.length });
+      // Report every bucket, not every 100th. Buckets are capped upstream
+      // (see MAX_BUCKET_SIZE), but comparison cost is quadratic in bucket
+      // size, so a batch of 100 large buckets could otherwise leave the
+      // progress bar frozen for minutes with the scan looking hung.
+      self.postMessage({ type: "detectionProgress", current: bi + 1, total: buckets.length });
     }
 
     self.postMessage({ type: "detectionResults", groups: allGroups });


### PR DESCRIPTION
The slider stopped at 0.90, which put looser matching out of reach entirely — useful when culling near-identical shots rather than exact duplicates, e.g. burst frames whose EXIF dates were rewritten.

This lowers the floor to 0.75. The default stays at 0.99, so nobody gets looser matching without asking for it, and the existing "More matches" / "Exact only" endpoint labels still describe the range.

Down at the new floor MobileNet groups photos that are merely similar rather than duplicate, so false positives are expected; the per-photo keep/trash review is what makes that safe.

5 new tests.

---

**Stacked on #142, #143, #144 and #145.** The change under review is `1071d8a` alone — a one-line change to the slider's `min` — and GitHub narrows this diff automatically as the parents merge.

This one is independent of the rest of the stack (it touches only `ScanConfig.tsx`); it's stacked purely so the whole set can be tested together. Happy to rebase it onto `main` on its own if you'd rather take it first.